### PR TITLE
BPC: add Empowered Shock Vortex timer (Fix #69)

### DIFF
--- a/DBM-Icecrown/TheCrimsonHall/BPCouncil.lua
+++ b/DBM-Icecrown/TheCrimsonHall/BPCouncil.lua
@@ -48,7 +48,8 @@ local timerTargetSwitch			= mod:NewTimer(47, "TimerTargetSwitch", 70952)	-- ever
 local timerDarkNucleusCD		= mod:NewCDTimer(10, 71943, nil, false, nil, 5)	-- usually every 10 seconds but sometimes more
 local timerConjureFlamesCD		= mod:NewCDTimer(20, 71718, nil, nil, nil, 3) -- every 20-30 seconds but never more often than every 20sec
 local timerGlitteringSparksCD	= mod:NewCDTimer(20, 71807, nil, nil, nil, 2) -- This is pretty nasty on heroic
-local timerShockVortex			= mod:NewCDTimer(15, 72037, nil, nil, nil, 3) -- Seen a range from 16,8 - 21,6
+local timerShockVortex			= mod:NewCDTimer(20, 72037, nil, nil, nil, 3, nil, nil, true) -- Seen a range from 16,8 - 21,6 (Warmane: from 2 logs: 19-22s). Added "keep" arg
+local timerEmpoweredShockVortex	= mod:NewCDTimer(30, 72039, nil, nil, nil, 3, nil, DBM_CORE_L.DEADLY_ICON, true)  -- Added "keep" arg
 local timerKineticBombCD		= mod:NewCDTimer(18, 72053, nil, "Ranged", nil, 1) -- Might need tweaking :23
 local timerShadowPrison			= mod:NewBuffFadesTimer(10, 72999, nil, nil, nil, 5) -- Hard mode debuff
 
@@ -78,7 +79,7 @@ function mod:OnCombatStart(delay)
 	warnTargetSwitchSoon:Schedule(42-delay)
 	warnTargetSwitchSoon:ScheduleVoice(42, "swapsoon")
 	timerTargetSwitch:Start(-delay)
-	timerShockVortex:Start(-delay)
+	timerEmpoweredShockVortex:Start(15-delay) -- Warmane: random 15-20
 	timerKineticBombCD:Start(20-delay)
 	activePrince = nil
 	table.wipe(glitteringSparksTargets)
@@ -148,7 +149,7 @@ function mod:SPELL_CAST_START(args)
 		if not self.Options.Sound72039 then
 			specWarnEmpoweredShockV:Play("scatter")
 		end
-		timerShockVortex:Start(30)
+		timerEmpoweredShockVortex:Start()
 		soundEmpoweredShockV:Play("Interface\\AddOns\\DBM-Core\\sounds\\RaidAbilities\\EmpoweredVortex.mp3")
 	elseif args.spellId == 71718 then	-- Conjure Flames
 		warnConjureFlames:Show()
@@ -167,15 +168,31 @@ function mod:SPELL_AURA_APPLIED(args)
 			warnTargetSwitchSoon:Schedule(42)
 			warnTargetSwitchSoon:ScheduleVoice(42, "swapsoon")
 			timerTargetSwitch:Start()
-		if self.Options.RangeFrame then
-			DBM.RangeCheck:Show(12)
+			if not timerEmpoweredShockVortex:IsStarted() then -- avoid overwriting first vortex
+				if timerShockVortex:IsStarted() then
+					timerEmpoweredShockVortex:Start(timerShockVortex:GetRemaining())
+				else
+					timerEmpoweredShockVortex:Start(20) -- random
+				end
+			end
+			timerShockVortex:Cancel()
+			if self.Options.RangeFrame then
+				DBM.RangeCheck:Show(12)
+			end
 		end
-	end
 	elseif args.spellId == 70981 and self:IsInCombat() then
 		warnTargetSwitch:Show(L.Keleseth)
 		warnTargetSwitchSoon:Schedule(42)
 		warnTargetSwitchSoon:ScheduleVoice(42, "swapsoon")
 		timerTargetSwitch:Start()
+		if not timerShockVortex:IsStarted() then
+			if timerEmpoweredShockVortex:IsStarted() then
+				timerShockVortex:Start(timerEmpoweredShockVortex:GetRemaining())
+				timerEmpoweredShockVortex:Cancel()
+			else
+				timerShockVortex:Start()
+			end
+		end
 		activePrince = args.destGUID
 		if self.Options.RangeFrame then
 			self:ScheduleMethod(4.5, "HideRange")--delay hiding range frame for a few seconds after change incase valanaar got a last second vortex cast off
@@ -185,6 +202,14 @@ function mod:SPELL_AURA_APPLIED(args)
 		warnTargetSwitchSoon:Schedule(42)
 		warnTargetSwitchSoon:ScheduleVoice(42, "swapsoon")
 		timerTargetSwitch:Start()
+		if not timerShockVortex:IsStarted() then
+			if timerEmpoweredShockVortex:IsStarted() then
+				timerShockVortex:Start(timerEmpoweredShockVortex:GetRemaining())
+				timerEmpoweredShockVortex:Cancel()
+			else
+				timerShockVortex:Start()
+			end
+		end
 		activePrince = args.destGUID
 		if self.Options.RangeFrame then
 			self:ScheduleMethod(4.5, "HideRange")--delay hiding range frame for a few seconds after change incase valanaar got a last second vortex cast off


### PR DESCRIPTION
There is an inherent random factor associated with these timers. The only timer that is reproducible is Empowered Shock Vortex to Empowered Shock Vortex, or Empowered Shock Vortex to the Shock Vortex right after it (30 seconds). Everything else fluctuates, based on logs.

To mitigate the random factor, I have passing the Keep argument as true, so the bar stays on screen until cancelled of restarted.

Additionally, I am checking bar remaining timers and started status, which might not be needed at all with the Keep now enabled.