### PR TITLE
Attempt to fix boss timers appearing where they shouldn't

### DIFF
--- a/DBM-Naxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Naxx/ArachnidQuarter/Maexxna.lua
@@ -23,11 +23,13 @@ local timerWebSpray		= mod:NewNextTimer(40.5, 29484, nil, nil, nil, 2)
 local timerSpider		= mod:NewTimer(30, "TimerSpider", 17332, nil, nil, 1)
 
 function mod:OnCombatStart(delay)
-	warnWebSpraySoon:Schedule(35.5 - delay)
-	timerWebSpray:Start(40.5 - delay)
-	warnSpidersSoon:Schedule(25 - delay)
-	warnSpidersNow:Schedule(30 - delay)
-	timerSpider:Start(30 - delay)
+	if (L.SubZoneName and GetSubZoneText() == L.SubZoneName) or not L.SubZoneName then -- Fix for Maexxna timers sometimes appearing on other boss
+		warnWebSpraySoon:Schedule(35.5 - delay)
+		timerWebSpray:Start(40.5 - delay)
+		warnSpidersSoon:Schedule(25 - delay)
+		warnSpidersNow:Schedule(30 - delay)
+		timerSpider:Start(30 - delay)
+	end
 end
 
 function mod:OnCombatEnd(wipe)

--- a/DBM-Naxx/ConstructQuarter/Gluth.lua
+++ b/DBM-Naxx/ConstructQuarter/Gluth.lua
@@ -18,9 +18,11 @@ local enrageTimer		= mod:NewBerserkTimer(420)
 local timerDecimate		= mod:NewCDTimer(104, 28374, nil, nil, nil, 2)
 
 function mod:OnCombatStart(delay)
-	enrageTimer:Start(420 - delay)
-	timerDecimate:Start(110 - delay)
-	warnDecimateSoon:Schedule(100 - delay)
+	if (L.ThaddiusSubZoneName and GetSubZoneText() ~= L.ThaddiusSubZoneName) or not L.ThaddiusSubZoneName then -- Fix for Gluth timers showing on Thaddius pull
+		enrageTimer:Start(420 - delay)
+		timerDecimate:Start(110 - delay)
+		warnDecimateSoon:Schedule(100 - delay)
+	end
 end
 
 function mod:SPELL_DAMAGE(_, _, _, _, _, _, spellId)

--- a/DBM-Naxx/FrostwyrmLair/Sapphiron.lua
+++ b/DBM-Naxx/FrostwyrmLair/Sapphiron.lua
@@ -56,38 +56,40 @@ local function Landing(self)
 end
 
 function mod:OnCombatStart(delay)
-	noTargetTime = 0
-	warned_lowhp = false
-	self.vb.isFlying = false
-	warnAirPhaseSoon:Schedule(38.5 - delay)
-	timerAirPhase:Start(48.5 - delay)
-	self:Schedule(46 - delay, DBM.RangeCheck.Show, DBM.RangeCheck, 12)
-	self:RegisterOnUpdateHandler(function(self, elapsed)
-		if not self:IsInCombat() then return end
-		local foundBoss, target
-		for uId in DBM:GetGroupMembers() do
-			local unitID = uId.."target"
-			if self:GetUnitCreatureId(unitID) == 15989 and UnitAffectingCombat(unitID) then
-				target = DBM:GetUnitFullName(unitID.."target")
-				foundBoss = true
-				break
+	if (L.SubZoneName and GetSubZoneText() == L.SubZoneName) or not L.SubZoneName then -- Check so Sapphiron timers don't appear on Kel'Thuzad
+		noTargetTime = 0
+		warned_lowhp = false
+		self.vb.isFlying = false
+		warnAirPhaseSoon:Schedule(38.5 - delay)
+		timerAirPhase:Start(48.5 - delay)
+		self:Schedule(46 - delay, DBM.RangeCheck.Show, DBM.RangeCheck, 12)
+		self:RegisterOnUpdateHandler(function(self, elapsed)
+			if not self:IsInCombat() then return end
+			local foundBoss, target
+			for uId in DBM:GetGroupMembers() do
+				local unitID = uId.."target"
+				if self:GetUnitCreatureId(unitID) == 15989 and UnitAffectingCombat(unitID) then
+					target = DBM:GetUnitFullName(unitID.."target")
+					foundBoss = true
+					break
+				end
 			end
-		end
-		if foundBoss and not target then
-			noTargetTime = noTargetTime + elapsed
-		elseif foundBoss then
-			noTargetTime = 0
-		end
-		if noTargetTime > 0.5 and not self.vb.isFlying then
-			noTargetTime = 0
-			self.vb.isFlying = true
-			self:Schedule(60, resetIsFlying, self)
-			timerDrainLife:Cancel()
-			timerAirPhase:Cancel()
-			warnAirPhaseNow:Show()
-			timerLanding:Start()
-		end
-	end, 0.2)
+			if foundBoss and not target then
+				noTargetTime = noTargetTime + elapsed
+			elseif foundBoss then
+				noTargetTime = 0
+			end
+			if noTargetTime > 0.5 and not self.vb.isFlying then
+				noTargetTime = 0
+				self.vb.isFlying = true
+				self:Schedule(60, resetIsFlying, self)
+				timerDrainLife:Cancel()
+				timerAirPhase:Cancel()
+				warnAirPhaseNow:Show()
+				timerLanding:Start()
+			end
+		end, 0.2)
+	end
 end
 
 function mod:OnCombatEnd()

--- a/DBM-Naxx/MilitaryQuarter/Horsemen.lua
+++ b/DBM-Naxx/MilitaryQuarter/Horsemen.lua
@@ -37,14 +37,16 @@ mod:SetBossHealthInfo(
 mod.vb.markCounter = 0
 
 function mod:OnCombatStart(delay)
-	self.vb.markCounter = 0
-	timerLadyMark:Start()
-	NextZeliekMark:Start()
-	NextBaronMark:Start()
-	NextThaneMark:Start()
-	warnMarkSoon:Schedule(12)
-	if self.Options.RangeFrame then
-		DBM.RangeCheck:Show(12)
+	if (L.SubZoneName and GetSubZoneText() == L.SubZoneName) or not L.SubZoneName then -- Check so 4 Horsemen timers don't appear on other bosses
+		self.vb.markCounter = 0
+		timerLadyMark:Start()
+		NextZeliekMark:Start()
+		NextBaronMark:Start()
+		NextThaneMark:Start()
+		warnMarkSoon:Schedule(12)
+		if self.Options.RangeFrame then
+			DBM.RangeCheck:Show(12)
+		end
 	end
 end
 

--- a/DBM-Naxx/PlagueQuarter/Loatheb.lua
+++ b/DBM-Naxx/PlagueQuarter/Loatheb.lua
@@ -31,15 +31,17 @@ mod.vb.doomCounter	= 0
 mod.vb.sporeTimer	= 36
 
 function mod:OnCombatStart(delay)
-	self.vb.doomCounter = 0
-	if self:IsDifficulty("normal25") then
-		self.vb.sporeTimer = 18
-	else
-		self.vb.sporeTimer = 36
+	if (L.SubZoneName and GetSubZoneText() == L.SubZoneName) or not L.SubZoneName then -- Fix for Loatheb timers appearing on other bosses
+		self.vb.doomCounter = 0
+		if self:IsDifficulty("normal25") then
+			self.vb.sporeTimer = 18
+		else
+			self.vb.sporeTimer = 36
+		end
+		timerSpore:Start(self.vb.sporeTimer - delay)
+		warnSporeSoon:Schedule(self.vb.sporeTimer - 5 - delay)
+		timerDoom:Start(120 - delay, self.vb.doomCounter + 1)
 	end
-	timerSpore:Start(self.vb.sporeTimer - delay)
-	warnSporeSoon:Schedule(self.vb.sporeTimer - 5 - delay)
-	timerDoom:Start(120 - delay, self.vb.doomCounter + 1)
 end
 
 function mod:SPELL_CAST_SUCCESS(args)

--- a/DBM-Naxx/localization.cn.lua
+++ b/DBM-Naxx/localization.cn.lua
@@ -70,7 +70,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer		= "蜘蛛克星"
+	ArachnophobiaTimer		= "蜘蛛克星",
+	--SubZoneName 			= "Maexxna's Nest"
 })
 
 ------------------------------
@@ -153,6 +154,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert		= "在团队中提示谁杀死了孢子并发送悄悄话给该玩家\n(需要团长或助理权限)"
 })
 
+L:SetMiscLocalization({
+	--SubZoneName 		= "The Necrotic Vault"
+})
+
 -----------------
 --  Patchwerk  --
 -----------------
@@ -188,6 +193,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "格拉斯"
+})
+
+L:SetMiscLocalization({
+	--ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 ----------------
@@ -310,7 +319,8 @@ L:SetMiscLocalization({
 	Korthazz			= "库尔塔兹领主",
 	Rivendare			= "瑞文戴尔男爵",
 	Blaumeux			= "女公爵布劳缪克丝",
-	Zeliek				= "瑟里耶克爵士"
+	Zeliek				= "瑟里耶克爵士",
+	--SubZoneName 		= "The Horsemen's Assembly"
 })
 
 -----------------
@@ -346,7 +356,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	EmoteBreath			= "%s深深地吸了一口气。"
+	EmoteBreath			= "%s深深地吸了一口气。",
+	--SubZoneName		= "Sapphiron's Lair"
 })
 
 ------------------

--- a/DBM-Naxx/localization.de.lua
+++ b/DBM-Naxx/localization.de.lua
@@ -66,7 +66,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer	= "Arachnophobie"
+	ArachnophobiaTimer	= "Arachnophobie",
+	--SubZoneName 		= "Maexxna's Nest"
 })
 
 ------------------------------
@@ -149,6 +150,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert	= "Sende Flüsternachricht und verkünde Spieler in Raid die Sporen beschädigen\n(benötigt aktivierte Ankündigungen und (L)- oder (A)-Status)"
 })
 
+L:SetMiscLocalization({
+	--SubZoneName 		= "The Necrotic Vault"
+})
+
 -----------------
 --  Patchwerk  --
 -----------------
@@ -184,6 +189,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "Gluth"
+})
+
+L:SetMiscLocalization({
+	--ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 ----------------
@@ -306,7 +315,8 @@ L:SetMiscLocalization({
 	Korthazz	= "Than Korth'azz",
 	Rivendare	= "Baron Totenschwur",
 	Blaumeux	= "Lady Blaumeux",
-	Zeliek		= "Sir Zeliek"
+	Zeliek		= "Sir Zeliek",
+	--SubZoneName = "The Horsemen's Assembly"
 })
 
 -----------------
@@ -342,7 +352,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	EmoteBreath			= "%s holt tief Luft."
+	EmoteBreath			= "%s holt tief Luft.",
+	--SubZoneName		= "Sapphiron's Lair"
 })
 
 ------------------

--- a/DBM-Naxx/localization.en.lua
+++ b/DBM-Naxx/localization.en.lua
@@ -65,7 +65,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer	= "Arachnophobia"
+	ArachnophobiaTimer	= "Arachnophobia",
+	SubZoneName 		= "Maexxna's Nest"
 })
 
 ------------------------------
@@ -148,6 +149,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert	= "Send whisper to and announce to raid players who damage spores\n(requires announce to be enabled and leader/promoted status)"
 })
 
+L:SetMiscLocalization({
+	SubZoneName 		= "The Necrotic Vault"
+})
+
 -----------------
 --  Patchwerk  --
 -----------------
@@ -183,6 +188,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "Gluth"
+})
+
+L:SetMiscLocalization({
+	ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 ----------------
@@ -306,7 +315,8 @@ L:SetMiscLocalization({
 	Korthazz	= "Thane Korth'azz",
 	Rivendare	= "Baron Rivendare",
 	Blaumeux	= "Lady Blaumeux",
-	Zeliek		= "Sir Zeliek"
+	Zeliek		= "Sir Zeliek",
+	SubZoneName = "The Horsemen's Assembly"
 })
 
 -----------------
@@ -342,7 +352,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	EmoteBreath			= "%s takes a deep breath."
+	EmoteBreath			= "%s takes a deep breath.",
+	SubZoneName			= "Sapphiron's Lair"
 })
 
 ------------------

--- a/DBM-Naxx/localization.es.lua
+++ b/DBM-Naxx/localization.es.lua
@@ -66,7 +66,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer	= "Logro: Aracnofobia"
+	ArachnophobiaTimer	= "Logro: Aracnofobia",
+	--SubZoneName 		= "Maexxna's Nest"
 })
 
 -----------------------
@@ -149,6 +150,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert	= "Enviar susurros y avisar a la banda de los jugadores que estén dañando esporas\n(necesita 'anunciar' activado y lider/ayudante)"
 })
 
+L:SetMiscLocalization({
+	--SubZoneName 		= "The Necrotic Vault"
+})
+
 ---------------
 -- Remendejo --
 ---------------
@@ -184,6 +189,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "Gluth"
+})
+
+L:SetMiscLocalization({
+	--ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 --------------
@@ -306,7 +315,8 @@ L:SetMiscLocalization({
 	Korthazz	= "Señor feudal Korth'azz",
 	Rivendare	= "Barón Osahendido",
 	Blaumeux	= "Lady Blaumeux",
-	Zeliek		= "Sir Zeliek"
+	Zeliek		= "Sir Zeliek",
+	--SubZoneName = "The Horsemen's Assembly"
 })
 
 ---------------
@@ -342,7 +352,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	EmoteBreath			= "%s respira hondo."
+	EmoteBreath			= "%s respira hondo.",
+	--SubZoneName		= "Sapphiron's Lair"
 })
 
 ----------------

--- a/DBM-Naxx/localization.fr.lua
+++ b/DBM-Naxx/localization.fr.lua
@@ -61,7 +61,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer	= "Arachnophobie"
+	ArachnophobiaTimer	= "Arachnophobie",
+	--SubZoneName 		= "Maexxna's Nest"
 })
 
 ------------------------------
@@ -140,6 +141,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert	= "Envoyer un murmure et annoncer aux joueurs de raid qui endommagent les spores\n(nécessite que l'annonce soit activée et le statut de leader/promu)"
 })
 
+L:SetMiscLocalization({
+	--SubZoneName 		= "The Necrotic Vault"
+})
+
 -----------------
 --  Patchwerk  --
 -----------------
@@ -175,6 +180,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "Gluth"
+})
+
+L:SetMiscLocalization({
+	--ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 ----------------
@@ -299,7 +308,8 @@ L:SetMiscLocalization({
 	Korthazz					= "Thane Korth'azz",
 	Rivendare					= "Baron Vaillefendre",
 	Blaumeux					= "Dame Blaumeux",
-	Zeliek						= "Sire Zeliek"
+	Zeliek						= "Sire Zeliek",
+	--SubZoneName = "The Horsemen's Assembly"
 })
 
 -----------------
@@ -335,7 +345,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	EmoteBreath			    = "prend une grande inspiration"
+	EmoteBreath			    = "prend une grande inspiration",
+	--SubZoneName			= "Sapphiron's Lair"
 })
 
 ------------------

--- a/DBM-Naxx/localization.kr.lua
+++ b/DBM-Naxx/localization.kr.lua
@@ -66,7 +66,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer	= "거미의 공포"
+	ArachnophobiaTimer	= "거미의 공포",
+	--SubZoneName 		= "Maexxna's Nest"
 })
 
 ---------------
@@ -148,6 +149,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert	= "포자에게 데미지를 주는 공격대원에게 귓속말 보내기 및 알리기\n(공대장 및 경보 권한이 있을 경우)"
 })
 
+L:SetMiscLocalization({
+	--SubZoneName 		= "The Necrotic Vault"
+})
+
 -----------------
 -- 피조물 지구 --
 -----------------
@@ -186,6 +191,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "글루스"
+})
+
+L:SetMiscLocalization({
+	--ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 ----------------
@@ -313,7 +322,8 @@ L:SetMiscLocalization({
 	Korthazz	= "영주 코스아즈",
 	Rivendare	= "남작 리븐데어",
 	Blaumeux	= "여군주 블라미우스",
-	Zeliek		= "젤리에크 경"
+	Zeliek		= "젤리에크 경",
+	--SubZoneName = "The Horsemen's Assembly"
 })
 
 -------------------
@@ -352,7 +362,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	EmoteBreath				= "숨을 깊게 들이마십니다."
+	EmoteBreath				= "숨을 깊게 들이마십니다.",
+	--SubZoneName			= "Sapphiron's Lair"
 })
 
 ------------------

--- a/DBM-Naxx/localization.ru.lua
+++ b/DBM-Naxx/localization.ru.lua
@@ -63,7 +63,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer	= "Арахнофобия"
+	ArachnophobiaTimer	= "Арахнофобия",
+	--SubZoneName 		= "Maexxna's Nest"
 })
 
 ------------------------------
@@ -146,6 +147,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert	= "Сообщать шепотом и объявлять в рейд игроков, наносящих урон спорам\n(требуются права лидера или помощника)"
 })
 
+L:SetMiscLocalization({
+	--SubZoneName 		= "The Necrotic Vault"
+})
+
 -----------------
 --  Patchwerk  --
 -----------------
@@ -181,6 +186,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "Глут"
+})
+
+L:SetMiscLocalization({
+	--ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 ----------------
@@ -303,7 +312,8 @@ L:SetMiscLocalization({
 	Korthazz	= "Тан Кортазз",
 	Rivendare	= "Барон Ривендер",
 	Blaumeux	= "Леди Бломе",
-	Zeliek		= "Сэр Зелиек"
+	Zeliek		= "Сэр Зелиек",
+	--SubZoneName = "The Horsemen's Assembly"
 })
 
 -----------------
@@ -339,7 +349,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	EmoteBreath			= "%s глубоко вдыхает."
+	EmoteBreath			= "%s глубоко вдыхает.",
+	--SubZoneName		= "Sapphiron's Lair"
 })
 
 ------------------

--- a/DBM-Naxx/localization.tw.lua
+++ b/DBM-Naxx/localization.tw.lua
@@ -62,7 +62,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	ArachnophobiaTimer	= "蜘蛛恐懼症"
+	ArachnophobiaTimer	= "蜘蛛恐懼症",
+	--SubZoneName 		= "Maexxna's Nest"
 })
 
 ------------------------------
@@ -141,6 +142,10 @@ L:SetOptionLocalization({
 	SporeDamageAlert	= "在團隊中提示誰殺死了孢子並發送密語給兇手\n(需要團隊隊長或助理權限)"
 })
 
+L:SetMiscLocalization({
+	--SubZoneName 		= "The Necrotic Vault"
+})
+
 -----------------
 --  Patchwerk  --
 -----------------
@@ -176,6 +181,10 @@ L = DBM:GetModLocalization("Gluth")
 
 L:SetGeneralLocalization({
 	name = "古魯斯"
+})
+
+L:SetMiscLocalization({
+	--ThaddiusSubZoneName = "The Halls of Reanimation"
 })
 
 ----------------
@@ -298,7 +307,8 @@ L:SetMiscLocalization({
 	Korthazz	= "寇斯艾茲族長",
 	Rivendare	= "瑞文戴爾男爵",
 	Blaumeux	= "布洛莫斯女士",
-	Zeliek		= "札里克爵士"
+	Zeliek		= "札里克爵士",
+	--SubZoneName = "The Horsemen's Assembly"
 })
 
 -----------------
@@ -335,6 +345,7 @@ L:SetOptionLocalization({
 
 L:SetMiscLocalization({
 	EmoteBreath			= "%s深深地吸了一口氣。",
+	--SubZoneName		= "Sapphiron's Lair"
 })
 
 ------------------


### PR DESCRIPTION
In Naxxramas there is a bug where sometimes boss timers appear on another boss on pull. From my experience I have noticed Maexxna timers appearing on 4 Horsemen, Loatheb timers appearing on Sapphiron, Gluth timers appearing on Thaddius. Also added check for 4 Horsemen and Sapphiron just in case.