### PR TITLE
Fix Thaddius polarity shift dropdown and text and Gruul dropdown position

### DIFF
--- a/DBM-GUI/DBM-GUI_DropDown.lua
+++ b/DBM-GUI/DBM-GUI_DropDown.lua
@@ -40,9 +40,20 @@ do
 	local MAX_BUTTONS = 10
 	local BackDropTable = { bgFile = "" }
 	local L = DBM_GUI_Translations
+	local CL = DBM_CORE_L
 
 	local TabFrame1 = CreateFrame("Frame", "DBM_GUI_DropDown", UIParent, "DBM_GUI_DropDownMenu")
 	local ClickFrame = CreateFrame("Button", nil, UIParent)
+
+	local function replaceSpellLinks(id)
+		local spellId = tonumber(id)
+		local spellName = DBM:GetSpellInfo(spellId)
+		if not spellName then
+			spellName = CL.UNKNOWN
+			DBM:Debug("Spell ID does not exist: "..spellId)
+		end
+		return ("|cff71d5ff|Hspell:%d|h%s|h|r"):format(spellId, spellName)
+	end
 
 	if ElvUI then
 		TabFrame1:SetBackdrop({
@@ -276,6 +287,11 @@ do
 				entry.text = entry.text or "Missing entry.text"
 				entry.value = entry.value or entry.text
 			end
+		end
+
+		-- font strings do not support hyperlinks, so check if we need one...
+		if title and title:find("%$spell:") then
+			title = title:gsub("%$spell:(%d+)", replaceSpellLinks)
 		end
 
 		-- Create the Dropdown Frame

--- a/DBM-GUI/DBM-GUI_DropDown.lua
+++ b/DBM-GUI/DBM-GUI_DropDown.lua
@@ -307,7 +307,7 @@ do
 					width = math.max(width, _G[dropdown:GetName().."Text"]:GetStringWidth())
 				end
 			end
-			if width > 300 then width = 300 end  -- Limit the width in case string has high width
+			if width > 400 then width = 400 end  -- Limit the width in case string has high width
 		end
 		dropdown:SetWidth(width + 30)	-- required to fix some setpoint problems
 		dropdown:SetHeight(height or 32)

--- a/DBM-GUI/DBM-GUI_DropDown.lua
+++ b/DBM-GUI/DBM-GUI_DropDown.lua
@@ -291,6 +291,7 @@ do
 					width = math.max(width, _G[dropdown:GetName().."Text"]:GetStringWidth())
 				end
 			end
+			if width > 300 then width = 300 end  -- Limit the width in case string has high width
 		end
 		dropdown:SetWidth(width + 30)	-- required to fix some setpoint problems
 		dropdown:SetHeight(height or 32)

--- a/DBM-Gruul/Gruul.lua
+++ b/DBM-Gruul/Gruul.lua
@@ -33,8 +33,8 @@ local timerGroundSlamCD	= mod:NewCDTimer(74, 33525, nil, nil, nil, 2)--74-80 sec
 local timerShatterCD	= mod:NewNextTimer(10, 33654, nil, nil, nil, 2, nil, DBM_CORE_L.DEADLY_ICON, nil, 1, 4)--10 seconds after ground slam
 --local timerSilenceCD	= mod:NewCDTimer(32, 36297, nil, nil, nil, 5, nil, DBM_CORE_L.HEALER_ICON)--Also showing a HUGE variation of 32-130 seconds.
 
-mod:AddDropdownOption("RangeDistance", {"Smaller", "Safe"}, "Safe", "misc")
 mod:AddRangeFrameOption(mod.Options.RangeDistance == "Smaller" and 11 or 18, 33654)
+mod:AddDropdownOption("RangeDistance", {"Smaller", "Safe"}, "Safe", "misc")
 
 function mod:OnCombatStart(delay)
 	timerGrowthCD:Start(-delay)

--- a/DBM-Gruul/localization.en.lua
+++ b/DBM-Gruul/localization.en.lua
@@ -20,7 +20,7 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	WarnGrowth		= "Show warning for $spell:36300",
-	RangeDistance	= "Range frame distance for |cff71d5ff|Hspell:33654|hShatter|h|r",
+	RangeDistance	= "Range frame distance for $spell:33654",
 	Smaller			= "Smaller distance (11)",
 	Safe			= "Safer distance (18)"
 })

--- a/DBM-Gruul/localization.kr.lua
+++ b/DBM-Gruul/localization.kr.lua
@@ -17,7 +17,7 @@ L:SetGeneralLocalization({
 
 L:SetOptionLocalization({
 	WarnGrowth	= "$spell:36300 알림 보기",
-	RangeDistance	= "|cff71d5ff|Hspell:33654|h산산조각|h|r 거리 창 범위 설정",
+	RangeDistance	= "$spell:33654 거리 창 범위 설정",
 	Smaller			= "좁은 범위 (11m)",
 	Safe			= "안전 범위 (18m)"
 })

--- a/DBM-Gruul/localization.ru.lua
+++ b/DBM-Gruul/localization.ru.lua
@@ -22,7 +22,7 @@ L:SetWarningLocalization({
 
 L:SetOptionLocalization({
 	WarnGrowth		= "Показывать предупреждение для $spell:36300",
-	RangeDistance	= "Фрейм дистанции для |cff71d5ff|Hspell:33654|hДробление|h|r",
+	RangeDistance	= "Фрейм дистанции для $spell:33654",
 	Smaller			= "Маленькая дистанция (11)",
 	Safe			= "Безопасная дистанция (18)"
 })

--- a/DBM-Naxx/ConstructQuarter/Thaddius.lua
+++ b/DBM-Naxx/ConstructQuarter/Thaddius.lua
@@ -25,6 +25,7 @@ local timerNextShift		= mod:NewNextTimer(30, 28089, nil, nil, nil, 2, nil, DBM_C
 local timerShiftCast		= mod:NewCastTimer(3, 28089, nil, nil, nil, 2)
 local timerThrow			= mod:NewNextTimer(20.6, 28338, nil, nil, nil, 5, nil, DBM_CORE_L.TANK_ICON)
 
+mod:AddMiscLine(DBM_CORE_L.OPTION_CATEGORY_DROPDOWNS)
 mod:AddDropdownOption("ArrowsEnabled", {"Never", "TwoCamp", "ArrowsRightLeft", "ArrowsInverse"}, "Never", "misc")
 
 mod:SetBossHealthInfo(

--- a/DBM-Naxx/localization.en.lua
+++ b/DBM-Naxx/localization.en.lua
@@ -202,7 +202,7 @@ L:SetWarningLocalization({
 L:SetOptionLocalization({
 	WarningChargeChanged	= "Show special warning when your polarity changed",
 	WarningChargeNotChanged	= "Show special warning when your polarity did not change",
-	ArrowsEnabled			= "Show arrows during $spell:28089",
+	ArrowsEnabled			= "Show arrows during |cff71d5ff|Hspell:28089|hPolarity Shift|h|r",
 	TwoCamp					= "Show arrows (normal \"2 camp\" run through strategy)",
 	ArrowsRightLeft			= "Show left/right arrows for the \"4 camp\" strategy (show left arrow if polarity changed, right if not)",
 	ArrowsInverse			= "Inverse \"4 camp\" strategy (show right arrow if polarity changed, left if not)"

--- a/DBM-Naxx/localization.en.lua
+++ b/DBM-Naxx/localization.en.lua
@@ -202,7 +202,7 @@ L:SetWarningLocalization({
 L:SetOptionLocalization({
 	WarningChargeChanged	= "Show special warning when your polarity changed",
 	WarningChargeNotChanged	= "Show special warning when your polarity did not change",
-	ArrowsEnabled			= "Show arrows during |cff71d5ff|Hspell:28089|hPolarity Shift|h|r",
+	ArrowsEnabled			= "Show arrows during $spell:28089",
 	TwoCamp					= "Show arrows (normal \"2 camp\" run through strategy)",
 	ArrowsRightLeft			= "Show left/right arrows for the \"4 camp\" strategy (show left arrow if polarity changed, right if not)",
 	ArrowsInverse			= "Inverse \"4 camp\" strategy (show right arrow if polarity changed, left if not)"


### PR DESCRIPTION
There is a bug with the dropdown in Thaddius options. If the string width was too high the button just went out of clickable bounds. 
Note that it was possible to fix this by adding \n to the string with high width in locale instead, but it made the dropdown look not so nice. If you think this will break something with menus then I will PR the \n fix instead. From what I checked everything seemed to stay same though.

Before:
![Thaddius bug showcase](https://user-images.githubusercontent.com/91183260/159043429-a5a1a441-a58b-4efc-b135-0344ed42f3ae.png)
After:
![Thaddius fix showcase](https://user-images.githubusercontent.com/91183260/159043476-785589ec-755c-4b43-ac2b-5ba4df336d53.png)



I also fixed the dropdown button overlapping in Gruul options.
![gruul old dropdown bug](https://user-images.githubusercontent.com/91183260/159044082-0bdf5ec8-d36f-422d-9df4-abfe5a4428ba.png)
Updated one looks like this
![gruul new dropdown fix](https://user-images.githubusercontent.com/91183260/159044141-3b3afe3c-9dce-4652-83ce-76e78294ae60.png)


