### PR TITLE
T7 add a couple timers

### DIFF
--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -9,6 +9,7 @@ mod:SetCreatureID(28860)
 mod:RegisterCombat("combat")
 
 mod:RegisterEventsInCombat(
+	"SPELL_CAST_START 56908 58956",
 	"SPELL_CAST_SUCCESS 57579 59127",
 	"SPELL_AURA_APPLIED 57491",
 	"SPELL_DAMAGE 59128",
@@ -17,6 +18,7 @@ mod:RegisterEventsInCombat(
 )
 
 local warnShadowFissure	    	= mod:NewSpellAnnounce(59127, 4, nil, nil, nil, nil, nil, 2)
+local warnBreathSoon			= mod:NewSoonAnnounce(58956, 2, nil, "Tank|Healer")
 local warnTenebron				= mod:NewAnnounce("WarningTenebron", 2, 61248, false)
 local warnShadron				= mod:NewAnnounce("WarningShadron", 2, 58105, false)
 local warnVesperon				= mod:NewAnnounce("WarningVesperon", 2, 61251, false)
@@ -30,6 +32,7 @@ local specWarnTenebronPortal	= mod:NewSpecialWarning("WarningTenebronPortal", fa
 local specWarnShadronPortal		= mod:NewSpecialWarning("WarningShadronPortal", false, nil, nil, 1, 7)
 
 local timerShadowFissure		= mod:NewCastTimer(5, 59128, nil, nil, nil, 3) --Cast timer until Void Blast. it's what happens when shadow fissure explodes.
+local timerBreath				= mod:NewCDTimer(10, 58956, nil, "Tank|Healer", nil, 5)
 local timerWall					= mod:NewCDTimer(30, 43113, nil, nil, nil, 2)
 local timerTenebron				= mod:NewTimer(30, "TimerTenebron", 61248, nil, nil, 1)
 local timerShadron				= mod:NewTimer(80, "TimerShadron", 58105, nil, nil, 1)
@@ -106,6 +109,8 @@ function mod:OnCombatStart(delay)
 	--Cache spellnames so a solo player check doesn't fail in CheckDrakes in 8.0+
 	self:Schedule(5, CheckDrakes, self, delay)
 	timerWall:Start(-delay)
+	warnBreathSoon:Schedule(5-delay)
+	timerBreath:Start(-delay)
 
 	twipe(lastvoids)
 	twipe(lastfire)
@@ -135,6 +140,13 @@ function mod:OnCombatEnd(wipe)
 	end
 	SendChatMessage(L.FireWalls:format(fire), "RAID")
 	twipe(sortedFails)
+end
+
+function mod:SPELL_CAST_START(args)
+	if args:IsSpellID(56908, 58956) then -- Flame breath
+		warnBreathSoon:Schedule(5.5)
+		timerBreath:Start(10.5)
+	end
 end
 
 function mod:SPELL_CAST_SUCCESS(args)

--- a/DBM-Naxx/ArachnidQuarter/Faerlina.lua
+++ b/DBM-Naxx/ArachnidQuarter/Faerlina.lua
@@ -8,6 +8,7 @@ mod:RegisterCombat("combat")
 
 mod:RegisterEventsInCombat(
 	"SPELL_AURA_APPLIED 28798 54100 28732 54097 28794 54099",
+	"SPELL_CAST_SUCCESS 28796 54098",
 	"UNIT_DIED"
 )
 
@@ -22,12 +23,14 @@ local specWarnGTFO			= mod:NewSpecialWarningGTFO(28794, nil, nil, nil, 1, 8)
 
 local timerEmbrace			= mod:NewBuffActiveTimer(30, 28732, nil, nil, nil, 6)
 local timerEnrage			= mod:NewCDTimer(60, 28131, nil, nil, nil, 6)
+local timerPoisonVolley		= mod:NewNextTimer(12, 54098, nil, nil, nil, 5)
 
 mod.vb.enraged = false
 
 function mod:OnCombatStart(delay)
 	timerEnrage:Start(-delay)
 	warnEnrageSoon:Schedule(55 - delay)
+	timerPoisonVolley:Start(-delay)
 	self.vb.enraged = false
 end
 
@@ -57,6 +60,12 @@ function mod:SPELL_AURA_APPLIED(args)
 	elseif args:IsSpellID(28794, 54099) and args:IsPlayer() then
 		specWarnGTFO:Show(args.spellName)
 		specWarnGTFO:Play("watchfeet")
+	end
+end
+
+function mod:SPELL_CAST_SUCCESS(args)
+	if args:IsSpellID(28796, 54098) then -- Poison Bolt Volley
+		timerPoisonVolley:Start(10)
 	end
 end
 

--- a/DBM-Naxx/ArachnidQuarter/Maexxna.lua
+++ b/DBM-Naxx/ArachnidQuarter/Maexxna.lua
@@ -19,15 +19,24 @@ local warnSpidersNow	= mod:NewAnnounce("WarningSpidersNow", 4, 17332)
 local specWarnWebWrap	= mod:NewSpecialWarningSwitch(28622, "RangedDps", nil, nil, 1, 2)
 local yellWebWrap		= mod:NewYellMe(28622)
 
-local timerWebSpray		= mod:NewNextTimer(40.5, 29484, nil, nil, nil, 2)
+local timerWebSpray		= mod:NewNextTimer(40, 29484, nil, nil, nil, 2)
 local timerSpider		= mod:NewTimer(30, "TimerSpider", 17332, nil, nil, 1)
 
+local function Spiderlings(self)
+	warnSpidersSoon:Schedule(35)
+	warnSpidersNow:Schedule(40)
+	timerSpider:Start(40)
+	self:Unschedule(Spiderlings)
+	self:Schedule(40, Spiderlings, self)
+end
+
 function mod:OnCombatStart(delay)
-	warnWebSpraySoon:Schedule(35.5 - delay)
-	timerWebSpray:Start(40.5 - delay)
+	warnWebSpraySoon:Schedule(35 - delay)
+	timerWebSpray:Start(40 - delay)
 	warnSpidersSoon:Schedule(25 - delay)
 	warnSpidersNow:Schedule(30 - delay)
 	timerSpider:Start(30 - delay)
+	self:Schedule(30 - delay, Spiderlings, self)
 end
 
 function mod:OnCombatEnd(wipe)
@@ -53,10 +62,7 @@ end
 function mod:SPELL_CAST_SUCCESS(args)
 	if args:IsSpellID(29484, 54125) then -- Web Spray
 		warnWebSprayNow:Show()
-		warnWebSpraySoon:Schedule(35.5)
+		warnWebSpraySoon:Schedule(35)
 		timerWebSpray:Start()
-		warnSpidersSoon:Schedule(25)
-		warnSpidersNow:Schedule(30)
-		timerSpider:Start()
 	end
 end

--- a/DBM-Naxx/MilitaryQuarter/Horsemen.lua
+++ b/DBM-Naxx/MilitaryQuarter/Horsemen.lua
@@ -20,10 +20,11 @@ local warnMeteor				= mod:NewSpellAnnounce(57467, 4)
 local specWarnMarkOnPlayer		= mod:NewSpecialWarning("SpecialWarningMarkOnPlayer", nil, nil, nil, 1, 6)
 
 local timerLadyMark				= mod:NewNextTimer(16, 28833)
-local NextZeliekMark			= mod:NewNextTimer(16, 28835)
-local NextBaronMark				= mod:NewNextTimer(15, 28834)
-local NextThaneMark				= mod:NewNextTimer(15, 28832)
-local holyWrathCD				= mod:NewCDTimer(13, 57466)
+local timerZeliekMark			= mod:NewNextTimer(16, 28835)
+local timerBaronMark			= mod:NewNextTimer(15, 28834)
+local timerThaneMark			= mod:NewNextTimer(15, 28832)
+local timerHolyWrathCD			= mod:NewCDTimer(13, 57466)
+local timerMeteorCD				= mod:NewCDTimer(15, 57467, nil, nil, nil, 2)
 
 mod:AddRangeFrameOption("12")
 
@@ -36,13 +37,21 @@ mod:SetBossHealthInfo(
 
 mod.vb.markCounter = 0
 
+-- Still 15s timer on next meteor when he skips one (usually on tank swaps)
+local function MeteorCast(self)
+	self:Unschedule(MeteorCast)
+	timerMeteorCD:Start()
+	self:Schedule(15, MeteorCast, self)
+end
+
 function mod:OnCombatStart(delay)
 	self.vb.markCounter = 0
 	timerLadyMark:Start()
-	NextZeliekMark:Start()
-	NextBaronMark:Start()
-	NextThaneMark:Start()
+	timerZeliekMark:Start()
+	timerBaronMark:Start()
+	timerThaneMark:Start()
 	warnMarkSoon:Schedule(12)
+	timerMeteorCD:Start()
 	if self.Options.RangeFrame then
 		DBM.RangeCheck:Show(12)
 	end
@@ -57,6 +66,7 @@ end
 function mod:SPELL_CAST_START(args)
 	if args:IsSpellID(28884, 57467) then
 		warnMeteor:Show()
+		MeteorCast(self)
 	end
 end
 
@@ -67,15 +77,15 @@ function mod:SPELL_CAST_SUCCESS(args)
 		if spellId == 28833 then -- Lady Mark
 			timerLadyMark:Start(15)
 		elseif spellId == 28835 then -- Zeliek Mark
-			NextZeliekMark:Start(15)
+			timerZeliekMark:Start(15)
 		elseif spellId == 28834 then -- Barok Mark
-			NextBaronMark:Start()
+			timerBaronMark:Start()
 		elseif spellId == 28832 then -- Thane Mark
-			NextThaneMark:Start()
+			timerThaneMark:Start()
 		end
 		warnMarkSoon:Schedule(12)
 	elseif args:IsSpellID(28883, 53638, 57466, 32455) then
-		holyWrathCD:Start()
+		timerHolyWrathCD:Start()
 	end
 end
 
@@ -92,12 +102,14 @@ end
 function mod:UNIT_DIED(args)
 	local cid = self:GetCIDFromGUID(args.destGUID)
 	if cid == 16064 then
-		NextThaneMark:Cancel()
+		timerThaneMark:Cancel()
+		timerMeteorCD:Cancel()
+		self:Unschedule(MeteorCast)
 	elseif cid == 30549 then
-		NextBaronMark:Cancel()
+		timerBaronMark:Cancel()
 	elseif cid == 16065 then
 		timerLadyMark:Cancel()
 	elseif cid == 16063 then
-		NextZeliekMark:Cancel()
+		timerZeliekMark:Cancel()
 	end
 end


### PR DESCRIPTION
Timers are based on when this was current content on Frostmourne S2. Assuming that they are still same as of now.

Note that for Grobbulus I added approximate timer for Slime Spray based on what I researched. It seems that each pull timers are different/randomized:
**25-man pull from May 2021:
34 after pull - 30 - 56 - 28 - 60**

**25-man pull from June 2021:
30 after pull - 32 - 62 - 24 - 62**

**25-man pull from July 2021:
30 after pull - 34 - 60 - 34 - 58 - 32**

**25-man pull from August 2021:
34 after pull - 32 - 56 - 32 - 56**

**25-man pull from Lordaeron in October 2021:
32 after pull - 26 - nothing for 57**

**10-man pull from Icecrown in April 2021:
36 after pull - 30**

I don't think they changed timers so often, it seems like each pull it just randomizes intervals to be used during boss. The consistency here is seperate 1st Spray and every 2/4/6.. is shorter, then every 3/5/7.. is long. I just approximated to 32 - 31 - 59. Maybe this will be changed for Frostmourne S3, will have to see then.