### PR TITLE
Sartharion: fix Drake debuff check

### DIFF
--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -52,11 +52,9 @@ local function isunitdebuffed(spellID)
 	local name = DBM:GetSpellInfo(spellID)
 	if not name then return false end
 
-	for i=1, DBM:GetNumGroupMembers(), 1 do
-		local debuffname = DBM:UnitDebuff("player", i, "HARMFUL")
-		if debuffname == name then
-			return true
-		end
+	local debuffname = DBM:UnitDebuff("player", spellID)
+	if debuffname == name then
+		return true
 	end
 	return false
 end

--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -52,9 +52,11 @@ local function isunitdebuffed(spellID)
 	local name = DBM:GetSpellInfo(spellID)
 	if not name then return false end
 
-	local debuffname = DBM:UnitDebuff("player", spellID)
-	if debuffname == name then
-		return true
+	for uId in DBM:GetGroupMembers() do
+		local debuffname = DBM:UnitDebuff(uId, spellID)
+		if debuffname == name then
+			return true
+		end
 	end
 	return false
 end


### PR DESCRIPTION
Looks like old code wanted to use Blizzard API to check for debuff but used DBM function instead, this resulted in nil being returned and timers not activating for Drake mechanics on OS 1D+.
https://github.com/Zidras/DBM-Warmane/blob/88728ccd0e7b8d1a3724fe9acadb5234918d1134/DBM-Core/DBM-Core.lua#L5871-L5880