### PR TITLE
Kel'Thuzad: safer Detonate Mana range

### DIFF
--- a/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
+++ b/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
@@ -45,7 +45,7 @@ local timerPhase2			= mod:NewTimer(227, "TimerPhase2", nil, nil, nil, 6)
 mod:AddSetIconOption("SetIconOnMC", 28410, true, false, {1, 2, 3})
 mod:AddSetIconOption("SetIconOnManaBomb", 27819, false, false, {8})
 mod:AddSetIconOption("SetIconOnFrostTomb", 28169, true, false, {1, 2, 3, 4, 5, 6, 7, 8})
-mod:AddRangeFrameOption(10, 27819)
+mod:AddRangeFrameOption(12, 27819)
 
 local RaidWarningFrame = RaidWarningFrame
 local GetFramesRegisteredForEvent, RaidNotice_AddMessage = GetFramesRegisteredForEvent, RaidNotice_AddMessage

--- a/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
+++ b/DBM-Naxx/FrostwyrmLair/Kel'Thuzad.lua
@@ -154,7 +154,7 @@ local function StartPhase2(self)
 			end
 		end
 		if self.Options.RangeFrame then
-			DBM.RangeCheck:Show(10)
+			DBM.RangeCheck:Show(12)
 		end
 	end
 end


### PR DESCRIPTION
12 yards seems to be the safer/more consistent option. Since the explosion range itself is 10 yards, sometimes it shows that nobody is in range and people still get touched by the damage.