### PR TITLE
Sartharion: cancel whelps timer after whelps spawn

### DIFF
--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -175,7 +175,7 @@ function mod:SPELL_DAMAGE(_, _, _, _, destName, _, spellId)
 end
 
 function mod:UNIT_TARGET(uId)
-	if self.vb.WhelpsSpawned == false and DBM:GetUnitCreatureId(uId.."target") == 31214 then -- Sartharion Twilight Whelp
+	if self.vb.WhelpsSpawned == false and DBM:GetUnitCreatureId(uId.."target") == 31214 and not UnitIsDead(uId.."target") then -- Sartharion Twilight Whelp
 		self.vb.WhelpsSpawned = true
 		timerTenebronWhelps:Cancel()
 	end

--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -37,7 +37,7 @@ local timerWall					= mod:NewCDTimer(30, 43113, nil, nil, nil, 2)
 local timerTenebron				= mod:NewTimer(30, "TimerTenebron", 61248, nil, nil, 1)
 local timerShadron				= mod:NewTimer(80, "TimerShadron", 58105, nil, nil, 1)
 local timerVesperon				= mod:NewTimer(120, "TimerVesperon", 61251, nil, nil, 1)
-local timerTenebronWhelps		= mod:NewTimer(60, "TimerTenebronWhelps", 1022, nil, nil, nil, nil, true) -- random timer (60 or 62) so add "keep" arg
+local timerTenebronWhelps		= mod:NewTimer(62, "TimerTenebronWhelps", 1022)
 local timerShadronPortal		= mod:NewTimer(94, "TimerShadronPortal", 11420)
 local timerVesperonPortal		= mod:NewTimer(139, "TimerVesperonPortal", 57988)
 local timerVesperonPortal2		= mod:NewTimer(199, "TimerVesperonPortal2", 57988) -- what's the purpose of this?
@@ -70,7 +70,7 @@ local function CheckDrakes(self, delay)
 		timerTenebron:Start(26 - delay) -- 30
 		warnTenebron:Schedule(21 - delay) -- 25
 		timerTenebronWhelps:Start(- delay)
-		warnTenebronWhelpsSoon:Schedule(55 - delay)
+		warnTenebronWhelpsSoon:Schedule(57 - delay)
 		if self.Options.HealthFrame then
 			DBM.BossHealth:AddBoss(30452, "Tenebron")
 		end

--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -13,7 +13,6 @@ mod:RegisterEventsInCombat(
 	"SPELL_CAST_SUCCESS 57579 59127",
 	"SPELL_AURA_APPLIED 57491",
 	"SPELL_DAMAGE 59128",
-	"UNIT_TARGET",
 	"CHAT_MSG_RAID_BOSS_EMOTE",
 	"CHAT_MSG_MONSTER_EMOTE"
 )
@@ -48,7 +47,6 @@ mod:AddBoolOption("AnnounceFails", true, "announce")
 local lastvoids = {}
 local lastfire = {}
 local tsort, tinsert, twipe = table.sort, table.insert, table.wipe
-mod.vb.WhelpsSpawned = false
 
 local function isunitdebuffed(spellID)
 	local name = DBM:GetSpellInfo(spellID)
@@ -73,7 +71,6 @@ local function CheckDrakes(self, delay)
 		warnTenebron:Schedule(21 - delay) -- 25
 		timerTenebronWhelps:Start(- delay)
 		warnTenebronWhelpsSoon:Schedule(55 - delay)
-		self.vb.WhelpsSpawned = false
 		if self.Options.HealthFrame then
 			DBM.BossHealth:AddBoss(30452, "Tenebron")
 		end
@@ -171,13 +168,6 @@ function mod:SPELL_DAMAGE(_, _, _, _, destName, _, spellId)
 	if self.Options.AnnounceFails and self.Options.Announce and spellId == 59128 and DBM:GetRaidRank() >= 1 and DBM:GetRaidUnitId(destName) ~= "none" and destName then
 		lastvoids[destName] = (lastvoids[destName] or 0) + 1
 		SendChatMessage(L.VoidZoneOn:format(destName), "RAID")
-	end
-end
-
-function mod:UNIT_TARGET(uId)
-	if self.vb.WhelpsSpawned == false and DBM:GetUnitCreatureId(uId.."target") == 31214 then -- Sartharion Twilight Whelp
-		self.vb.WhelpsSpawned = true
-		timerTenebronWhelps:Cancel()
 	end
 end
 

--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -13,6 +13,7 @@ mod:RegisterEventsInCombat(
 	"SPELL_CAST_SUCCESS 57579 59127",
 	"SPELL_AURA_APPLIED 57491",
 	"SPELL_DAMAGE 59128",
+	"UNIT_TARGET",
 	"CHAT_MSG_RAID_BOSS_EMOTE",
 	"CHAT_MSG_MONSTER_EMOTE"
 )
@@ -47,6 +48,7 @@ mod:AddBoolOption("AnnounceFails", true, "announce")
 local lastvoids = {}
 local lastfire = {}
 local tsort, tinsert, twipe = table.sort, table.insert, table.wipe
+mod.vb.WhelpsSpawned = false
 
 local function isunitdebuffed(spellID)
 	local name = DBM:GetSpellInfo(spellID)
@@ -71,6 +73,7 @@ local function CheckDrakes(self, delay)
 		warnTenebron:Schedule(21 - delay) -- 25
 		timerTenebronWhelps:Start(- delay)
 		warnTenebronWhelpsSoon:Schedule(55 - delay)
+		self.vb.WhelpsSpawned = false
 		if self.Options.HealthFrame then
 			DBM.BossHealth:AddBoss(30452, "Tenebron")
 		end
@@ -168,6 +171,13 @@ function mod:SPELL_DAMAGE(_, _, _, _, destName, _, spellId)
 	if self.Options.AnnounceFails and self.Options.Announce and spellId == 59128 and DBM:GetRaidRank() >= 1 and DBM:GetRaidUnitId(destName) ~= "none" and destName then
 		lastvoids[destName] = (lastvoids[destName] or 0) + 1
 		SendChatMessage(L.VoidZoneOn:format(destName), "RAID")
+	end
+end
+
+function mod:UNIT_TARGET(uId)
+	if self.vb.WhelpsSpawned == false and DBM:GetUnitCreatureId(uId.."target") == 31214 then -- Sartharion Twilight Whelp
+		self.vb.WhelpsSpawned = true
+		timerTenebronWhelps:Cancel()
 	end
 end
 

--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -37,7 +37,7 @@ local timerWall					= mod:NewCDTimer(30, 43113, nil, nil, nil, 2)
 local timerTenebron				= mod:NewTimer(30, "TimerTenebron", 61248, nil, nil, 1)
 local timerShadron				= mod:NewTimer(80, "TimerShadron", 58105, nil, nil, 1)
 local timerVesperon				= mod:NewTimer(120, "TimerVesperon", 61251, nil, nil, 1)
-local timerTenebronWhelps		= mod:NewTimer(62, "TimerTenebronWhelps", 1022)
+local timerTenebronWhelps		= mod:NewTimer(60, "TimerTenebronWhelps", 1022)
 local timerShadronPortal		= mod:NewTimer(94, "TimerShadronPortal", 11420)
 local timerVesperonPortal		= mod:NewTimer(139, "TimerVesperonPortal", 57988)
 local timerVesperonPortal2		= mod:NewTimer(199, "TimerVesperonPortal2", 57988) -- what's the purpose of this?
@@ -70,7 +70,7 @@ local function CheckDrakes(self, delay)
 		timerTenebron:Start(26 - delay) -- 30
 		warnTenebron:Schedule(21 - delay) -- 25
 		timerTenebronWhelps:Start(- delay)
-		warnTenebronWhelpsSoon:Schedule(57 - delay)
+		warnTenebronWhelpsSoon:Schedule(55 - delay)
 		if self.Options.HealthFrame then
 			DBM.BossHealth:AddBoss(30452, "Tenebron")
 		end

--- a/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
+++ b/DBM-ChamberOfAspects/Obsidian/Sartharion.lua
@@ -175,7 +175,7 @@ function mod:SPELL_DAMAGE(_, _, _, _, destName, _, spellId)
 end
 
 function mod:UNIT_TARGET(uId)
-	if self.vb.WhelpsSpawned == false and DBM:GetUnitCreatureId(uId.."target") == 31214 and not UnitIsDead(uId.."target") then -- Sartharion Twilight Whelp
+	if self.vb.WhelpsSpawned == false and DBM:GetUnitCreatureId(uId.."target") == 31214 then -- Sartharion Twilight Whelp
 		self.vb.WhelpsSpawned = true
 		timerTenebronWhelps:Cancel()
 	end


### PR DESCRIPTION
Canceling the timer on first whelp targeted. Right now the keep argument makes the timer last for the whole fight.