### PR TITLE
Range Check: attempt to fix incorrect previous range after bossMode

### DIFF
--- a/DBM-Core/DBM-RangeCheck.lua
+++ b/DBM-Core/DBM-RangeCheck.lua
@@ -1263,7 +1263,8 @@ function rangeCheck:DisableBossMode()
 	if mainFrame and mainFrame.bossMode then
 		mainFrame.bossMode = false
 		mainFrame.bossUnit = nil
-		mainFrame.range = mainFrame.previousRange or restoreRange
+		mainFrame.range = mainFrame.previousRange
+		restoreRange = mainFrame.range
 		if not mainFrame.previouslyShown then
 			self:Hide()
 		end

--- a/DBM-Core/DBM-RangeCheck.lua
+++ b/DBM-Core/DBM-RangeCheck.lua
@@ -1272,7 +1272,7 @@ function rangeCheck:DisableBossMode()
 end
 
 function rangeCheck:Hide(force)
-	if restoreRange and not force then -- Restore range frame to way it was when boss mod is done with it
+	if not DBM.Options.DontRestoreRange and restoreRange and not force then -- Restore range frame to way it was when boss mod is done with it
 		rangeCheck:Show(restoreRange, restoreFilter, true, restoreThreshold, restoreReverse)
 	else
 		restoreRange, restoreFilter, restoreThreshold, restoreReverse = nil, nil, nil, nil

--- a/DBM-Core/DBM-RangeCheck.lua
+++ b/DBM-Core/DBM-RangeCheck.lua
@@ -1226,6 +1226,7 @@ function rangeCheck:Show(range, filter, forceshow, redCircleNumPlayers, reverse,
 	if not restrictionsActive and (DBM.Options.RangeFrameFrames == "radar" or DBM.Options.RangeFrameFrames == "both") and not radarFrame:IsShown() then
 		radarFrame:Show()
 	end
+	mainFrame.previousRange = mainFrame.range or range
 	mainFrame.range = range
 	mainFrame.filter = filter
 	mainFrame.redCircleNumPlayers = redCircleNumPlayers
@@ -1233,7 +1234,6 @@ function rangeCheck:Show(range, filter, forceshow, redCircleNumPlayers, reverse,
 	mainFrame.hideTime = hideTime and (GetTime() + hideTime) or 0
 	mainFrame.restrictions = restrictionsActive
 	mainFrame.onlySummary = onlySummary
-	mainFrame.previousRange = mainFrame.range or range
 	mainFrame.previouslyShown = true
 	mainFrame.bossUnit = bossUnit
 	mainFrame.bossMode = bossUnit ~= nil
@@ -1263,7 +1263,7 @@ function rangeCheck:DisableBossMode()
 	if mainFrame and mainFrame.bossMode then
 		mainFrame.bossMode = false
 		mainFrame.bossUnit = nil
-		mainFrame.range = restoreRange
+		mainFrame.range = mainFrame.previousRange or restoreRange
 		if not mainFrame.previouslyShown then
 			self:Hide()
 		end


### PR DESCRIPTION
If DBM.Options.DontRestoreRange is true then restoreRange will be nil, since it doesn't get assigned non-nil anywhere else. 
Otherwise it will be set to the current range passed by SetBossRange(), since it passes forceshow argument as true.
https://github.com/Zidras/DBM-Warmane/blob/f989be67418f4053c24b3d9397fe0b9eac4de721/DBM-Core/DBM-RangeCheck.lua#L1249-L1260

Then DisableBossMode() will set current range either to nil (and lua nil error from OnUpdate function) or the one that bossMode was using rather than previous one before it.
https://github.com/Zidras/DBM-Warmane/blob/f989be67418f4053c24b3d9397fe0b9eac4de721/DBM-Core/DBM-RangeCheck.lua#L1262-L1271