### PR TITLE
SSC-Tidewalker1

### DIFF
--- a/DBM-Serpentshrine/DBM-Serpentshrine.toc
+++ b/DBM-Serpentshrine/DBM-Serpentshrine.toc
@@ -26,6 +26,7 @@ localization.en.lua
 localization.cn.lua
 localization.de.lua
 localization.es.lua
+localization.fr.lua
 localization.kr.lua
 localization.ru.lua
 localization.tw.lua

--- a/DBM-Serpentshrine/Tidewalker.lua
+++ b/DBM-Serpentshrine/Tidewalker.lua
@@ -13,7 +13,8 @@ mod:RegisterEventsInCombat(
 	"SPELL_AURA_APPLIED 37850 38023 38024 38025 38049",
 	"SPELL_CAST_START 37730",
 	"SPELL_CAST_SUCCESS 37764",
-	"SPELL_SUMMON 37854"
+	"SPELL_SUMMON 37854",
+	"CHAT_MSG_RAID_BOSS_EMOTE"
 )
 
 local warnTidal			= mod:NewSpellAnnounce(37730, 3)
@@ -22,7 +23,7 @@ local warnBubble		= mod:NewSpellAnnounce(37854, 4)
 
 local specWarnMurlocs	= mod:NewSpecialWarning("SpecWarnMurlocs")
 
-local timerGraveCD		= mod:NewCDTimer(28.5, 38049, nil, nil, nil, 3)
+local timerGraveCD		= mod:NewCDTimer(30, 38049, nil, nil, nil, 3)
 local timerMurlocs		= mod:NewTimer(51, "TimerMurlocs", 39088, nil, nil, 1)
 local timerBubble		= mod:NewBuffActiveTimer(35, 37854, nil, nil, nil, 1)
 
@@ -34,7 +35,7 @@ mod.vb.graveIcon = 8
 local function showGraveTargets()
 	warnGrave:Show(table.concat(warnGraveTargets, "<, >"))
 	table.wipe(warnGraveTargets)
-	timerGraveCD:Show()
+	--timerGraveCD:Show()
 end
 
 function mod:OnCombatStart(delay)
@@ -52,7 +53,7 @@ function mod:SPELL_AURA_APPLIED(args)
 			self:SetIcon(args.destName, self.vb.graveIcon)
 		end
 		self.vb.graveIcon = self.vb.graveIcon - 1
-		if #warnGraveTargets >= 4 then
+		if #warnGraveTargets >= 1 then
 			showGraveTargets()
 		else
 			self:Schedule(0.3, showGraveTargets)
@@ -66,8 +67,17 @@ function mod:SPELL_CAST_START(args)
 	end
 end
 
-function mod:SPELL_CAST_SUCCESS(args)
+--[[function mod:SPELL_CAST_SUCCESS(args)
 	if args.spellId == 37764 then
+		specWarnMurlocs:Show()
+		timerMurlocs:Start()
+	end
+end]]
+
+function mod:CHAT_MSG_RAID_BOSS_EMOTE(msg)
+	if msg == L.Grave or msg:find(L.Grave) then
+		timerGraveCD:Show()
+	elseif msg == L.Murlocs or msg:find(L.Murlocs) then
 		specWarnMurlocs:Show()
 		timerMurlocs:Start()
 	end

--- a/DBM-Serpentshrine/Tidewalker.lua
+++ b/DBM-Serpentshrine/Tidewalker.lua
@@ -1,7 +1,7 @@
 local mod	= DBM:NewMod("Tidewalker", "DBM-Serpentshrine")
 local L		= mod:GetLocalizedStrings()
 
-mod:SetRevision("20220518110528")
+mod:SetRevision("20220608233256")
 mod:SetCreatureID(21213)
 
 mod:SetModelID(20739)
@@ -10,9 +10,9 @@ mod:SetUsedIcons(5, 6, 7, 8)
 mod:RegisterCombat("combat")
 
 mod:RegisterEventsInCombat(
-	"SPELL_AURA_APPLIED 37850 38023 38024 38025 38049",
 	"SPELL_CAST_START 37730",
 	"SPELL_CAST_SUCCESS 37764",
+	"SPELL_AURA_APPLIED 37850 38023 38024 38025 38049",
 	"SPELL_SUMMON 37854",
 	"CHAT_MSG_RAID_BOSS_EMOTE"
 )
@@ -21,10 +21,10 @@ local warnTidal			= mod:NewSpellAnnounce(37730, 3)
 local warnGrave			= mod:NewTargetNoFilterAnnounce(38049, 4)--TODO, make run out special warning instead?
 local warnBubble		= mod:NewSpellAnnounce(37854, 4)
 
-local specWarnMurlocs	= mod:NewSpecialWarning("SpecWarnMurlocs")
+local specWarnMurlocs	= mod:NewSpecialWarning("SpecWarnMurlocs", nil, nil, nil, nil, nil, nil, 24984, 37764)
 
-local timerGraveCD		= mod:NewCDTimer(30, 38049, nil, nil, nil, 3)
-local timerMurlocs		= mod:NewTimer(51, "TimerMurlocs", 39088, nil, nil, 1)
+local timerGraveCD		= mod:NewCDTimer(30, 38049, nil, nil, nil, 3) -- 25 man log 2022/07/27 - 30.1, 30.0, 30.0, 30.0, 30.0
+local timerMurlocs		= mod:NewTimer(51, "TimerMurlocs", 39088, nil, nil, 1, nil, nil, nil, nil, nil, nil, nil, 37764)
 local timerBubble		= mod:NewBuffActiveTimer(35, 37854, nil, nil, nil, 1)
 
 mod:AddSetIconOption("GraveIcon", 38049, true, false, {5, 6, 7, 8})
@@ -41,24 +41,8 @@ end
 function mod:OnCombatStart(delay)
 	self.vb.graveIcon = 8
 	table.wipe(warnGraveTargets)
-	timerGraveCD:Start(20-delay)
-	timerMurlocs:Start(41-delay)
-end
-
-function mod:SPELL_AURA_APPLIED(args)
-	if args:IsSpellID(37850, 38023, 38024, 38025, 38049) then
-		warnGraveTargets[#warnGraveTargets + 1] = args.destName
-		self:Unschedule(showGraveTargets)
-		if self.Options.GraveIcon then
-			self:SetIcon(args.destName, self.vb.graveIcon)
-		end
-		self.vb.graveIcon = self.vb.graveIcon - 1
-		if #warnGraveTargets >= 1 then
-			showGraveTargets()
-		else
-			self:Schedule(0.3, showGraveTargets)
-		end
-	end
+	timerGraveCD:Start(19.4-delay) -- REVIEW! variance? (25 man log 2022/07/27) - 19.4
+	timerMurlocs:Start(40.5-delay) -- REVIEW! variance? (25 man log 2022/07/27) - 40.5
 end
 
 function mod:SPELL_CAST_START(args)
@@ -74,12 +58,22 @@ end
 	end
 end]]
 
-function mod:CHAT_MSG_RAID_BOSS_EMOTE(msg)
-	if msg == L.Grave or msg:find(L.Grave) then
-		timerGraveCD:Show()
-	elseif msg == L.Murlocs or msg:find(L.Murlocs) then
-		specWarnMurlocs:Show()
-		timerMurlocs:Start()
+function mod:SPELL_AURA_APPLIED(args)
+	if args:IsSpellID(37850, 38023, 38024, 38025, 38049) then
+		warnGraveTargets[#warnGraveTargets + 1] = args.destName
+		self:Unschedule(showGraveTargets)
+		if self.Options.GraveIcon then
+			self:SetIcon(args.destName, self.vb.graveIcon)
+		end
+		self.vb.graveIcon = self.vb.graveIcon - 1
+		if #warnGraveTargets >= 4 then
+			showGraveTargets()
+		else
+			self:Schedule(0.3, showGraveTargets)
+		end
+		if self:AntiSpam(2, 2) then
+			timerGraveCD:Start()
+		end
 	end
 end
 
@@ -87,5 +81,14 @@ function mod:SPELL_SUMMON(args)
 	if args.spellId == 37854 and self:AntiSpam(30) then
 		warnBubble:Show()
 		timerBubble:Start()
+	end
+end
+
+function mod:CHAT_MSG_RAID_BOSS_EMOTE(msg)
+--[[if msg == L.Grave or msg:find(L.Grave) then
+		timerGraveCD:Show()
+	else]]if msg == L.Murlocs or msg:find(L.Murlocs) then
+		specWarnMurlocs:Show()
+		timerMurlocs:Start()
 	end
 end

--- a/DBM-Serpentshrine/localization.cn.lua
+++ b/DBM-Serpentshrine/localization.cn.lua
@@ -136,6 +136,11 @@ L:SetOptionLocalization({
 	TimerMurlocs	= "显示鱼人群出现计时"--Translate
 })
 
+L:SetMiscLocalization({
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "猛烈的地震警告了附近的鱼人们！"
+})
+
 -----------------
 --  Lady Vashj --
 -----------------

--- a/DBM-Serpentshrine/localization.de.lua
+++ b/DBM-Serpentshrine/localization.de.lua
@@ -124,6 +124,11 @@ L:SetOptionLocalization({
 	TimerMurlocs	= "Zeige Zeit bis Murlocs erscheinen"
 })
 
+L:SetMiscLocalization({
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "Das heftige Erdbeben hat nahe Murlocs alarmiert!"
+})
+
 -----------------
 --  Lady Vashj --
 -----------------

--- a/DBM-Serpentshrine/localization.en.lua
+++ b/DBM-Serpentshrine/localization.en.lua
@@ -124,8 +124,8 @@ L:SetOptionLocalization({
 })
 
 L:SetMiscLocalization({
-	Grave  = "%s sends his enemies to their watery graves!",
-	Murlocs	= "The violent earthquake has alerted nearby Murlocs!"
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "The violent earthquake has alerted nearby Murlocs!"
 })
 
 -----------------

--- a/DBM-Serpentshrine/localization.en.lua
+++ b/DBM-Serpentshrine/localization.en.lua
@@ -123,6 +123,11 @@ L:SetOptionLocalization({
 	TimerMurlocs	= "Show timer for Murlocs spawning"
 })
 
+L:SetMiscLocalization({
+	Grave  = "%s sends his enemies to their watery graves!",
+	Murlocs	= "The violent earthquake has alerted nearby Murlocs!"
+})
+
 -----------------
 --  Lady Vashj --
 -----------------

--- a/DBM-Serpentshrine/localization.es.lua
+++ b/DBM-Serpentshrine/localization.es.lua
@@ -127,6 +127,11 @@ L:SetOptionLocalization({
 	TimerMurlocs	= "Mostrar temporizador para los siguientes múrlocs"
 })
 
+L:SetMiscLocalization({
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "¡El violento terremoto ha alertado a los múrlocs cercanos!"
+})
+
 -----------------
 --  Lady Vashj --
 -----------------

--- a/DBM-Serpentshrine/localization.fr.lua
+++ b/DBM-Serpentshrine/localization.fr.lua
@@ -1,0 +1,47 @@
+if GetLocale() ~= "frFR" then return end
+local L
+
+---------------------------
+--  Hydross the Unstable --
+---------------------------
+--L = DBM:GetModLocalization("Hydross")
+
+-----------------------
+--  The Lurker Below --
+-----------------------
+L = DBM:GetModLocalization("LurkerBelow")
+
+L:SetGeneralLocalization({
+	name = "Le Rôdeur d'En bas"
+})
+
+--------------------------
+--  Leotheras the Blind --
+--------------------------
+--L = DBM:GetModLocalization("Leotheras")
+
+-----------------------------
+--  Fathom-Lord Karathress --
+-----------------------------
+--L = DBM:GetModLocalization("Fathomlord")
+
+--------------------------
+--  Morogrim Tidewalker --
+--------------------------
+L = DBM:GetModLocalization("Tidewalker")
+
+L:SetMiscLocalization({
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "La violence du tremblement de terre a alerté des murlocs qui passaient non loin !"
+})
+
+-----------------
+--  Lady Vashj --
+-----------------
+L = DBM:GetModLocalization("Vashj")
+
+L:SetMiscLocalization({
+	DBM_VASHJ_YELL_PHASE2	= "L'heure est venue ! N'épargnez personne !",
+	DBM_VASHJ_YELL_PHASE3	= "Il faudrait peut-être vous mettre à l'abri.",
+	LootMsg					= "([^%s]+).*Hitem:(%d+)"
+})

--- a/DBM-Serpentshrine/localization.kr.lua
+++ b/DBM-Serpentshrine/localization.kr.lua
@@ -124,6 +124,11 @@ L:SetOptionLocalization({
 	TimerMurlocs	= "멀록 등장 타이머 바 보기"
 })
 
+L:SetMiscLocalization({
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "근처에 있던 멀록들이 격렬한 지진을 느끼고 주위로 달려듭니다!"
+})
+
 -----------------
 --  Lady Vashj --
 -----------------

--- a/DBM-Serpentshrine/localization.ru.lua
+++ b/DBM-Serpentshrine/localization.ru.lua
@@ -106,12 +106,6 @@ L:SetGeneralLocalization({
 	name = "Повелитель глубин Каратресс"
 })
 
-
-
-
-
-
-
 L:SetMiscLocalization({
 	Caribdis	= "Fathom-Guard Caribdis",--Translate
 	Tidalvess	= "Fathom-Guard Tidalvess",--Translate
@@ -140,6 +134,11 @@ L:SetOptionLocalization({
 	WarnMurlocs		= "Объявить Мурлоки",
 	SpecWarnMurlocs	= "Show special warning when Murlocs spawning",--Translate
 	TimerMurlocs	= "Show timer for Murlocs spawning"--Translate
+})
+
+L:SetMiscLocalization({
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "Сильный толчок землетрясения насторожил мурлоков поблизости!"
 })
 
 -----------------

--- a/DBM-Serpentshrine/localization.tw.lua
+++ b/DBM-Serpentshrine/localization.tw.lua
@@ -124,6 +124,11 @@ L:SetOptionLocalization({
 	TimerMurlocs	= "為魚人出現顯示計時器"
 })
 
+L:SetMiscLocalization({
+--	Grave			= "%s sends his enemies to their watery graves!",
+	Murlocs			= "強烈的地震驚動了附近的魚人!"
+})
+
 -----------------
 --  Lady Vashj --
 -----------------


### PR DESCRIPTION
1. Tidewalker casts Watery Grave every 30s.

2. Watery Grave can miss, so changed >=4 to >=1.

3. [Warmane bug?] Watery Grave doesn't always cast every 30s, even though the boss emote still goes off on schedule. Use the boss emote instead of the aura_applied to trigger the timer. (Skips to every other -> 60s, bugged on one pull.)

4. [Warmane bug?] Tidewalker doesn't cast Earthquake after his first one, but the boss emote still goes off on schedule. Use the boss emote instead of the cast to trigger the timer. (Seems like if he is tanked in one spot, he won't cast Earthquake again. He will cast it correctly each time he is re-positioned after casting Earthquake.)

5. Added the boss emotes to en localization.