### PR TITLE
Update for Naj'entus and Supremus Enrage timers

### DIFF
--- a/DBM-BlackTemple/Najentus.lua
+++ b/DBM-BlackTemple/Najentus.lua
@@ -23,7 +23,7 @@ local yellSpine			= mod:NewYell(39837)
 
 local timerShield		= mod:NewCDTimer(56, 39872, nil, nil, nil, 5)
 
-local berserkTimer		= mod:NewBerserkTimer(480)
+local berserkTimer		= mod:NewBerserkTimer(300)
 
 mod:AddSetIconOption("SpineIcon", 39837)
 mod:AddInfoFrameOption(39878, true)

--- a/DBM-BlackTemple/Supremus.lua
+++ b/DBM-BlackTemple/Supremus.lua
@@ -20,7 +20,7 @@ mod:RegisterEventsInCombat(
 local warnPhase			= mod:NewAnnounce("WarnPhase", 4, 42052)
 
 local timerPhase		= mod:NewTimer(60, "TimerPhase", 42052, nil, nil, 6)
-local berserkTimer		= mod:NewBerserkTimer(900)
+local berserkTimer		= mod:NewBerserkTimer(600)
 
 -- Stage One: Supremus
 mod:AddTimerLine(DBM_CORE_L.SCENARIO_STAGE:format(1)..": "..L.name)


### PR DESCRIPTION
Naj'entus 
5 min (300s) enrage timer

Supremus
* 9min and 10 second enrage (starts and ramps up during the kite phase, but doesn't kill you yet), you basically have until 10 minutes to kill him*

I feel having the enrage timer at 10 min (600s) gives the best representation of the fight.