### PR TITLE
Add enrage timer to TeronGorefiend.lua

### DIFF
--- a/DBM-BlackTemple/TeronGorefiend.lua
+++ b/DBM-BlackTemple/TeronGorefiend.lua
@@ -28,6 +28,8 @@ local timerDeathCD			= mod:NewCDTimer(32, 40251, nil, nil, nil, 3)--32-40 (small
 local timerDeath			= mod:NewTargetTimer(55, 40251, nil, nil, nil, 3)
 local timerVengefulSpirit	= mod:NewTimer(60, "TimerVengefulSpirit", 40325, nil, nil, 1)
 
+local berserkTimer			= mod:NewBerserkTimer(300)
+
 mod:AddSetIconOption("CrushIcon", 40243, false, false, {1, 2, 3, 4, 5})
 
 local CrushedTargets = {}
@@ -39,7 +41,8 @@ local function showCrushedTargets(self)
 	self.vb.crushIcon = 1
 end
 
-function mod:OnCombatStart()
+function mod:OnCombatStart(delay)
+	berserkTimer:Start(-delay)
 	table.wipe(CrushedTargets)
 	timerDeathCD:Start(11.1)--11-13?
 end

--- a/DBM-BlackTemple/TeronGorefiend.lua
+++ b/DBM-BlackTemple/TeronGorefiend.lua
@@ -44,7 +44,7 @@ end
 function mod:OnCombatStart(delay)
 	berserkTimer:Start(-delay)
 	table.wipe(CrushedTargets)
-	timerDeathCD:Start(11.1)--11-13?
+	timerDeathCD:Start(11.1-delay)--11-13?
 end
 
 function mod:SPELL_AURA_APPLIED(args)

--- a/DBM-BlackTemple/TeronGorefiend.lua
+++ b/DBM-BlackTemple/TeronGorefiend.lua
@@ -1,7 +1,7 @@
 local mod	= DBM:NewMod("TeronGorefiend", "DBM-BlackTemple")
 local L		= mod:GetLocalizedStrings()
 
-mod:SetRevision("20220518110528")
+mod:SetRevision("20230129114417")
 mod:SetCreatureID(22871)
 
 mod:SetModelID(21254)


### PR DESCRIPTION
I've noticed that warmane has added a 5 minute enrage timer to the teron Gorefiend fight in Black temple timewalking.
This excerpt from the transcript should show that the boss has a 300second enrage timer:

-------------------------------
["UNIT_SPELLCAST_SUCCEEDED"] = {
"Berserk-npc:22871-332 = pull:299.3", -- [1]

-------------------------------

["MONSTER"] = {
            "<13.19 22:32:06> [CHAT_MSG_MONSTER_YELL] Vengeance is mine!:Teron Gorefiend:::::0:0::0:3525::0:", -- [1]

["UNIT_SPELLCAST"] = {
"<313.20 22:37:06> [UNIT_SPELLCAST_SUCCEEDED] Teron Gorefiend(*player name redacted*) -Berserk- [[target:Berserk::0:]]", -- [74]

--------------------

If the first was not enough, here you can see that the difference between the combat start and berserk is also 300 seconds