### PR TITLE
Core: fix icon announcing

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20230404194630"),
+	Revision = parseCurseDate("20230407161248"),
 	DisplayVersion = "10.0.22", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2023, 3, 14) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }

--- a/DBM-Core/modules/Icons.lua
+++ b/DBM-Core/modules/Icons.lua
@@ -87,19 +87,19 @@ do
 			end
 			if CustomIcons then
 				SetRaidTarget(v, startIcon[icon])--do not use SetIcon function again. It already checked in SetSortedIcon function.
-				icon = icon + 1
 				if returnFunc then
 					mod[returnFunc](mod, v, startIcon[icon])--Send icon and target to returnFunc. (Generally used by announce icon targets to raid chat feature)
 				end
+				icon = icon + 1
 			else
 				SetRaidTarget(v, icon)--do not use SetIcon function again. It already checked in SetSortedIcon function.
+				if returnFunc then
+					mod[returnFunc](mod, v, icon)--Send unitId and icon to returnFunc. (Generally used by announce icon targets to raid chat feature)
+				end
 				if descendingIcon then
 					icon = icon - 1
 				else
 					icon = icon + 1
-				end
-				if returnFunc then
-					mod[returnFunc](mod, v, icon)--Send unitId and icon to returnFunc. (Generally used by announce icon targets to raid chat feature)
 				end
 			end
 		end
@@ -288,19 +288,19 @@ do
 			end
 			if CustomIcons then
 				SetRaidTarget(v, startIcon[icon])--do not use SetIcon function again. It already checked in SetSortedIcon function.
-				icon = icon + 1
 				if returnFunc then
 					mod[returnFunc](mod, v, startIcon[icon])--Send icon and target to returnFunc. (Generally used by announce icon targets to raid chat feature)
 				end
+				icon = icon + 1
 			else
 				SetRaidTarget(v, icon)--do not use SetIcon function again. It already checked in SetSortedIcon function.
+				if returnFunc then
+					mod[returnFunc](mod, v, icon)--Send unitId and icon to returnFunc. (Generally used by announce icon targets to raid chat feature)
+				end
 				if descendingIcon then
 					icon = icon - 1
 				else
 					icon = icon + 1
-				end
-				if returnFunc then
-					mod[returnFunc](mod, v, icon)--Send unitId and icon to returnFunc. (Generally used by announce icon targets to raid chat feature)
 				end
 			end
 		end


### PR DESCRIPTION
SetIconByTable and SetIconBySortedTable was bumping icon index before firing the returnFunc, causing all icon announces to be shifted by one index.
![image](https://user-images.githubusercontent.com/10605951/230633628-d8d4f7ea-f94e-452e-98d1-890bbe48464c.png)
![image](https://user-images.githubusercontent.com/10605951/230633637-aa47bb68-8c1f-40c0-a4ab-1963852f4246.png)

Verified by Emi on Sindragosa: Frost Beacon icon announces were being index-shifted by +1 and ended up on {rt9}

![image](https://user-images.githubusercontent.com/10605951/230633550-ab987332-853c-494a-b915-13814c38c4a1.png)
