### PR TITLE
typo fix

### DIFF
--- a/DBM-AQ40/CThun.lua
+++ b/DBM-AQ40/CThun.lua
@@ -65,7 +65,7 @@ do
 			local uId = DBM:GetRaidUnitId(name)
 			if uId then
 				--First, display their stomach debuff stacks
-				local spellName, _, _, count = DBM:UnitDebuf(uId, 26476)
+				local spellName, _, _, count = DBM:UnitDebuff(uId, 26476)
 				if spellName and count then
 					addLine(name, count)
 				end


### PR DESCRIPTION
DBM:UnitDebuff instead of  DBM:UnitDebuf

found by luaError ingame:
![HOb8fGv8bP](https://github.com/user-attachments/assets/6d8b5a81-a494-4a7f-892d-b3f1bdaf2cc5)
