### PR TITLE
Add Mana Tombs alternative Map File Name

### DIFF
--- a/DBM-Core/DBM-RangeCheck.lua
+++ b/DBM-Core/DBM-RangeCheck.lua
@@ -233,6 +233,9 @@ DBM:RegisterMapSize("MagtheridonsLair",	-- Magtheridon's Lair (Raid-BC)
 DBM:RegisterMapSize("Mana-Tombs",		-- Mana-Tombs (Party-BC)
 	1, 823.28515625, 548.85681152329994
 )
+DBM:RegisterMapSize("ManaTombs",		-- Mana-Tombs (Party-BC) Alternative Name
+	1, 823.28515625, 548.85681152329994 -- (Map name returned by [MPQ Patch] Classic/BC Dungeon Maps for WotLK)
+)
 DBM:RegisterMapSize("Maraudon",			-- Maraudon (Party-Classic)
 	1, 975, 650,
 	2, 1637.5, 1091.666000367


### PR DESCRIPTION
The [[MPQ Patch] Classic/BC Dungeon Maps for WotLK](https://forum.warmane.com/showthread.php?t=424250) map patch returns ManaTombs as the mapFileName from GetMapInfo() function. I don't know if there are other patches that make it as Mana-Tombs, so I just added an additional entry with the alternative name. Otherwise this throws an error:
https://github.com/Zidras/DBM-Warmane/blob/60a9631f452a9a4e41d84b5104e14239940b3163/DBM-Core/DBM-Core.lua#L6556-L6563

Here is what GetMapInfo() prints when standing inside Mana-Tombs with this specific patch:
![examplereturn](https://github.com/user-attachments/assets/ba052959-1cc5-4934-8c5f-28d204ccf3d5)
