### PR TITLE
Magtheridon: Add blast nova counter to addtime

### DIFF
--- a/DBM-Magtheridon/Magtheridon.lua
+++ b/DBM-Magtheridon/Magtheridon.lua
@@ -83,7 +83,7 @@ function mod:CHAT_MSG_MONSTER_YELL(msg)
 		-- +18 to the timers
 		timerConflagration:AddTime(18)
 		timerQuake:AddTime(18)
-		timerBlastNovaCD:AddTime(18)
+		timerBlastNovaCD:AddTime(18, self.vb.blastNovaCounter)
 		timerDebris:Start()
 	end
 end


### PR DESCRIPTION
Forgot to include the counter when adding time on P3 transition.

On a side note, apparently some people are having overlapping bars after the latest update? From what I heard Conflag bar and Blast Nova was overlapping, but I didn't have this issue. Maybe you have some more insight into it?