### PR TITLE
Magtheridon: Add Warnings and keep arg to Quake, small edits

### DIFF
--- a/DBM-Magtheridon/Magtheridon.lua
+++ b/DBM-Magtheridon/Magtheridon.lua
@@ -15,9 +15,11 @@ mod:RegisterEventsInCombat(
 )
 
 --Get custom voice pack sound for cubes
-local warningHeal			= mod:NewSpellAnnounce(30528, 3)
-local warningInfernal		= mod:NewSpellAnnounce(30511, 2)
+local warnHeal				= mod:NewSpellAnnounce(30528, 3)
+local warnInfernal			= mod:NewSpellAnnounce(30511, 2)
 local warnPhase2			= mod:NewPhaseAnnounce(2)
+local warnConflagration		= mod:NewSpellAnnounce(30757, 2)
+local warnQuake				= mod:NewSpellAnnounce(30657, 2, "Interface\\Icons\\Spell_Nature_Earthquake")
 local warnPhase3			= mod:NewPhaseAnnounce(3)
 
 local specWarnBlastNova		= mod:NewSpecialWarningInterrupt(30616, nil, nil, nil, 3, 2)
@@ -26,7 +28,7 @@ local specWarnHeal			= mod:NewSpecialWarningInterrupt(30528, "HasInterrupt", nil
 local timerHeal				= mod:NewCastTimer(2, 30528, nil, nil, nil, 4, nil, DBM_COMMON_L.INTERRUPT_ICON)
 local timerPhase2			= mod:NewTimer(120, "timerP2", "Interface\\Icons\\INV_Weapon_Halberd16", nil, nil, 6)
 local timerConflagration	= mod:NewCDTimer(30, 30757, nil, nil, nil, 2, nil, nil, true)
-local timerQuake			= mod:NewCDTimer(50, 30657, nil, nil, nil, 2, "Interface\\Icons\\Spell_Nature_Earthquake")
+local timerQuake			= mod:NewCDTimer(50, 30657, nil, nil, nil, 2, "Interface\\Icons\\Spell_Nature_Earthquake", nil, true)
 local timerBlastNovaCD		= mod:NewCDCountTimer(60, 30616, nil, nil, nil, 2, nil, DBM_COMMON_L.DEADLY_ICON)
 local timerDebris			= mod:NewNextTimer(15, 36449, nil, nil, nil, 2, nil, DBM_COMMON_L.HEALER_ICON..DBM_COMMON_L.TANK_ICON)--Only happens once per fight, after the phase 3 yell.
 
@@ -45,7 +47,7 @@ function mod:SPELL_CAST_START(args)
 			specWarnHeal:Play("kickcast")
 			timerHeal:Start()
 		else
-			warningHeal:Show()
+			warnHeal:Show()
 		end
 	elseif args.spellId == 30616 then
 		self.vb.blastNovaCounter = self.vb.blastNovaCounter + 1
@@ -57,7 +59,7 @@ end
 
 function mod:SPELL_CAST_SUCCESS(args)
 	if args.spellId == 30511 and self:AntiSpam(3, 1) then
-		warningInfernal:Show()
+		warnInfernal:Show()
 	end
 end
 
@@ -91,9 +93,11 @@ end
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, spellName)
 	if spellName == GetSpellInfo(30657) then
 		timerQuake:Start()
+		warnQuake:Show()
 	-- "<99.72 20:36:19> [UNIT_SPELLCAST_SUCCEEDED] Magtheridon(31.4%-0.0%){Target:Player} -Blaze- [[boss1:Blaze::0:]]", -- [1219]
 	-- "<100.03 20:36:19> [CLEU] SPELL_AURA_APPLIED#0x0F000000000A3F3A#Player#0x0F000000000A3F3A#Player#30757#Conflagration#DEBUFF#nil#", -- [1220]
 	elseif spellName == GetSpellInfo(40637) then
 		timerConflagration:Start()
+		warnConflagration:Show()
 	end
 end

--- a/DBM-Magtheridon/Magtheridon.lua
+++ b/DBM-Magtheridon/Magtheridon.lua
@@ -32,11 +32,11 @@ local timerQuake			= mod:NewCDTimer(50, 30657, nil, nil, nil, 2, "Interface\\Ico
 local timerBlastNovaCD		= mod:NewCDCountTimer(60, 30616, nil, nil, nil, 2, nil, DBM_COMMON_L.DEADLY_ICON)
 local timerDebris			= mod:NewNextTimer(15, 36449, nil, nil, nil, 2, nil, DBM_COMMON_L.HEALER_ICON..DBM_COMMON_L.TANK_ICON)--Only happens once per fight, after the phase 3 yell.
 
-mod.vb.blastNovaCounter = 1
+mod.vb.blastNovaCounter = 0
 
 function mod:OnCombatStart(delay)
 	self:SetStage(1)
-	self.vb.blastNovaCounter = 1
+	self.vb.blastNovaCounter = 0
 	timerPhase2:Start(-delay)
 end
 
@@ -53,7 +53,7 @@ function mod:SPELL_CAST_START(args)
 		self.vb.blastNovaCounter = self.vb.blastNovaCounter + 1
 		specWarnBlastNova:Show(L.name)
 		specWarnBlastNova:Play("kickcast")
-		timerBlastNovaCD:Start(nil, self.vb.blastNovaCounter)
+		timerBlastNovaCD:Start(nil, self.vb.blastNovaCounter + 1)
 	end
 end
 
@@ -67,7 +67,7 @@ function mod:CHAT_MSG_MONSTER_YELL(msg)
 	if (msg == L.DBM_MAG_YELL_PHASE2 or msg:find(L.DBM_MAG_YELL_PHASE2) or msg == L.DBM_MAG_ALTERNATIVE_YELL_PHASE2 or msg:find(L.DBM_MAG_ALTERNATIVE_YELL_PHASE2)) and self:GetStage(2, 1) then-- Alternative yell not in line with Blizzard: https://www.warmane.com/bugtracker/report/124104
 		self:SetStage(2)
 		warnPhase2:Show()
-		timerBlastNovaCD:Start(nil, self.vb.blastNovaCounter)
+		timerBlastNovaCD:Start(nil, self.vb.blastNovaCounter + 1)
 		timerPhase2:Cancel()
 		timerConflagration:Start(10) -- First Conflagration cd at least 10-25 (15 sec randomness)
 		timerQuake:Start(40) -- First Quake in 40 seconds
@@ -85,7 +85,7 @@ function mod:CHAT_MSG_MONSTER_YELL(msg)
 		-- +18 to the timers
 		timerConflagration:AddTime(18)
 		timerQuake:AddTime(18)
-		timerBlastNovaCD:AddTime(18, self.vb.blastNovaCounter)
+		timerBlastNovaCD:AddTime(18, self.vb.blastNovaCounter + 1)
 		timerDebris:Start()
 	end
 end

--- a/DBM-Magtheridon/Magtheridon.lua
+++ b/DBM-Magtheridon/Magtheridon.lua
@@ -1,7 +1,7 @@
 local mod	= DBM:NewMod("Magtheridon", "DBM-Magtheridon")
 local L		= mod:GetLocalizedStrings()
 
-mod:SetRevision("20240923211930")
+mod:SetRevision("20241008150020")
 mod:SetCreatureID(17257)
 
 mod:SetModelID(18527)

--- a/DBM-Magtheridon/Magtheridon.lua
+++ b/DBM-Magtheridon/Magtheridon.lua
@@ -75,12 +75,12 @@ function mod:CHAT_MSG_MONSTER_YELL(msg)
 		self:SetStage(3)
 		warnPhase3:Show()
 		--If time less than 20, extend existing timer to 20, else do nothing
-		--[[if timerBlastNovaCD:GetRemaining(self.vb.blastNovaCounter) < 20 then
-			local elapsed, total = timerBlastNovaCD:GetTime(self.vb.blastNovaCounter)
+		--[[if timerBlastNovaCD:GetRemaining(self.vb.blastNovaCounter + 1) < 20 then
+			local elapsed, total = timerBlastNovaCD:GetTime(self.vb.blastNovaCounter + 1)
 			local extend = 20 - (total-elapsed)
 			DBM:Debug("timerBlastNovaCD extended by: "..extend, 2)
 			timerBlastNovaCD:Stop()
-			timerBlastNovaCD:Update(elapsed, total+extend, self.vb.blastNovaCounter)
+			timerBlastNovaCD:Update(elapsed, total+extend, self.vb.blastNovaCounter + 1)
 		end]]
 		-- +18 to the timers
 		timerConflagration:AddTime(18)


### PR DESCRIPTION
There are scenarios where Conflagration and Quake can get "queued" by a few seconds. Conflag has the keep arg already, so just adding it to Quake also. Also figured might as well add warnings for those 2 spells.

Also edited the counter to be in line with standard as seen in other bosses where it starts from 0.