### PR TITLE
[PVP] AB/EOS parse maxResources from GetWorldStateUIInfo score text

### DIFF
--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -4,7 +4,7 @@ local L		= mod:GetLocalizedStrings()
 local DBM = DBM
 local AceTimer = LibStub("AceTimer-3.0")
 
-mod:SetRevision("20220827002800")
+mod:SetRevision("20241119131458")
 mod:SetZone(DBM_DISABLE_ZONE_DETECTION)
 
 mod:RegisterEvents(

--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -1032,7 +1032,23 @@ do
 						hordeBases = hordeBases + 1
 					end
 				end
-				self:UpdateWinTimer(1600, tonumber(smatch((select(3, GetWorldStateUIInfo(subscribedMapID == 483 and 2 or 1)) or ""), "(%d+)/1600")) or 0, tonumber(smatch((select(3, GetWorldStateUIInfo(subscribedMapID == 483 and 3 or 2)) or ""), "(%d+)/1600")) or 0, allyBases, hordeBases)
+
+				local isEotS = subscribedMapID == 483
+				local allyIndex = isEotS and 2 or 1
+				local hordeIndex = isEotS and 3 or 2
+
+				-- ex ab: "Bases: 0 Resources: 0/1600"
+				local allyScoreText = select(3, GetWorldStateUIInfo(allyIndex)) or ""
+				local hordeScoreText = select(3, GetWorldStateUIInfo(hordeIndex)) or ""
+
+				local allyCurrent, maxResources = allyScoreText:match("Resources:%s*(%d+)/(%d+)")
+				allyCurrent = tonumber(allyCurrent) or 0
+				maxResources = tonumber(maxResources) or 1600
+
+				local hordeCurrent = hordeScoreText:match("Resources:%s*(%d+)")
+				hordeCurrent = tonumber(hordeCurrent) or 0
+
+				self:UpdateWinTimer(maxResources, allyCurrent, hordeCurrent, allyBases, hordeBases)
 			end
 		end
 	end

--- a/DBM-PvP/PvPGeneral.lua
+++ b/DBM-PvP/PvPGeneral.lua
@@ -1041,11 +1041,11 @@ do
 				local allyScoreText = select(3, GetWorldStateUIInfo(allyIndex)) or ""
 				local hordeScoreText = select(3, GetWorldStateUIInfo(hordeIndex)) or ""
 
-				local allyCurrent, maxResources = allyScoreText:match("Resources:%s*(%d+)/(%d+)")
+				local allyCurrent, maxResources = smatch(allyScoreText, "(%d+)/(%d+)")
 				allyCurrent = tonumber(allyCurrent) or 0
 				maxResources = tonumber(maxResources) or 1600
 
-				local hordeCurrent = hordeScoreText:match("Resources:%s*(%d+)")
+				local hordeCurrent = smatch(hordeScoreText, "(%d+)/")
 				hordeCurrent = tonumber(hordeCurrent) or 0
 
 				self:UpdateWinTimer(maxResources, allyCurrent, hordeCurrent, allyBases, hordeBases)


### PR DESCRIPTION
max resources in AB on onyxia realm are 2000
possibly different on other realms?
suggested solution under testing to parse it correctly. needs cross realm testing

all on english locale
**Onyxia** (level 60+) **AB:**
![image](https://github.com/user-attachments/assets/330bec17-86ac-4b2b-adce-831aa5567bb0)

**Blackrock** (level 80) **AB:**
![image](https://github.com/user-attachments/assets/984aff90-8bcf-4aa0-a588-dd70abace144)
 
 **Blackrock** (level 80) **EOS:**
![image](https://github.com/user-attachments/assets/5a5a4769-010e-4d08-b11b-66b5cdf3af27)