### PR TITLE
Core: implement variance timer

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241212102112"),
+	Revision = parseCurseDate("20241212214114"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -6528,11 +6528,11 @@ do
 		testTimer7:Stop("Next Stage")
 		testTimer8:Stop("Custom User Bar")
 		testTimer1:Start("v5-10", "Test Bar showing 5s Variance")
-		testTimer2:Start("v10-30", "Adds")
+		testTimer2:Start("v25-30", "Adds")
 		testTimer3:Start(43, "Evil Debuff")
-		testTimer4:Start("v15-20", "Important Interrupt")
+		testTimer4:Start(20, "Important Interrupt")
 		testTimer5:Start(60, "Boom!")
-		testTimer6:Start(35, "Handle your Role")
+		testTimer6:Start("v32-35", "Handle your Role")
 		testTimer7:Start(50, "Next Stage")
 		testTimer8:Start(55, "Custom User Bar")
 		testWarning1:Cancel()

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241208233607"),
+	Revision = parseCurseDate("20241209223619"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -10052,7 +10052,7 @@ do
 									if DBM.Options.BadTimerAlert and bar.timer > correctWithVarianceDuration(1, bar) then--If greater than 1 seconds off, report this out of debug mode to all users
 										DBM:AddMsg("Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug")
 										fireEvent("DBM_Debug", "Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug", 2)
-									elseif bar.timer < correctWithVarianceDuration(-5, bar) then -- arbitrary limit. Would be useful to implement a variance detector, and report outside the known variance, however this would need to happen on a timer after it was refreshed.
+									elseif bar.timer < -0.1 then -- Would be useful to implement a variance detector, and report outside the known variance, however this would need to happen on a timer after it was refreshed. For the moment, only "keep" arg can achieve this.
 										DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero. Remaining time is : "..remaining, 2)
 									elseif bar.timer > correctWithVarianceDuration(0.1, bar) then
 										DBM:Debug("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer..")", 2)
@@ -10061,7 +10061,7 @@ do
 									if DBM.Options.BadTimerAlert and bar.timer > 1 then--If greater than 1 seconds off, report this out of debug mode to all users
 										DBM:AddMsg("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining..". Please report this bug")
 										fireEvent("DBM_Debug", "Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining..". Please report this bug", 2)
-									elseif bar.timer < -5 then
+									elseif bar.timer < -5 then -- arbitrary threshold
 										DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero. Remaining time is : "..remaining, 2)
 									elseif bar.timer > 0.1 then
 										DBM:Debug("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining, 2)
@@ -10141,7 +10141,7 @@ do
 								if DBM.Options.BadTimerAlert and bar.timer > correctWithVarianceDuration(1, bar) then--If greater than 1 seconds off, report this out of debug mode to all users
 									DBM:AddMsg("Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug")
 									fireEvent("DBM_Debug", "Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug", 2)
-								elseif bar.timer < correctWithVarianceDuration(-5, bar) then -- arbitrary limit. Would be useful to implement a variance detector, and report outside the known variance, however this would need to happen on a timer after it was refreshed.
+								elseif bar.timer < -0.1 then -- Would be useful to implement a variance detector, and report outside the known variance, however this would need to happen on a timer after it was refreshed. For the moment, only "keep" arg can achieve this.
 									DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero. Remaining time is : "..remaining, 2)
 								elseif bar.timer > correctWithVarianceDuration(0.1, bar) then
 									DBM:Debug("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer..")", 2)
@@ -10150,7 +10150,7 @@ do
 								if DBM.Options.BadTimerAlert and bar.timer > 1 then--If greater than 1 seconds off, report this out of debug mode to all users
 									DBM:AddMsg("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining..". Please report this bug")
 									fireEvent("DBM_Debug", "Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining..". Please report this bug", 2)
-								elseif bar.timer < -5 then
+								elseif bar.timer < -5 then -- arbitrary threshold
 									DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero. Remaining time is : "..remaining, 2)
 								elseif bar.timer > 0.1 then
 									DBM:Debug("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining, 2)

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241208172819"),
+	Revision = parseCurseDate("20241208184611"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -9990,11 +9990,15 @@ do
 			return timer -- Normal number timer, no variance
 		end
 
-		-- Check for variance format like "v30-40" or "dv30-40"
+		-- Check for variance format like "v30.5-40" or "dv30.5-40"
 		if type(timer) == "string" then
-			if not timer:match("^(d?v)(%d+)%-(%d+)$") then return end
+			-- ^(d?v) matches starting character d (optional) or v
+			-- (%d+%.?%d*) matches any number of digits with optional decimal
+			-- %- matches literal character "-"
+			-- (%d+%.?%d*)$ matches any number of digits with optional decimal, at the end of the string
+			if not timer:match("^(d?v)(%d+%.?%d*)%-(%d+%.?%d*)$") then return end
 
-			local minTimer, maxTimer = timer:match("v(%d+)%-(%d+)")
+			local minTimer, maxTimer = timer:match("v(%d+%.?%d*)%-(%d+%.?%d*)")
 			minTimer, maxTimer = tonumber(minTimer), tonumber(maxTimer)
 			local varianceDuration = maxTimer - minTimer
 
@@ -10011,7 +10015,7 @@ do
 			if DBM.Options.DontShowTrashTimers and self.mod.isTrashMod then return end
 		end
 		local timerStringWithVariance, minTimer
-		if type(timer) == "string" and timer:match("^v%d+-%d+$") then -- catch "timer variance" pattern, expressed like v10-20
+		if type(timer) == "string" and timer:match("^v%d+%.?%d*-%d+%.?%d*$") then -- catch "timer variance" pattern, expressed like v10.5-20.5
 			timerStringWithVariance = timer -- cache timer string
 			timer, minTimer = parseVarianceFromTimer(timer) -- use highest possible value as the actual End timer
 		end
@@ -10584,7 +10588,7 @@ do
 		end
 		local hasVariance, timerStringWithVariance, minTimer, varianceDuration
 		if type(timer) == "string" then
-			if timer:match("^v%d+-%d+") then -- parse variance, e.g. "v20-25"
+			if timer:match("^v%d+%.?%d*%-%d+%.?%d*$") then -- parse variance, e.g. "v20.5-25.5"
 				hasVariance = true
 				timerStringWithVariance = timer
 				timer, minTimer, varianceDuration = parseVarianceFromTimer(timer)
@@ -10643,11 +10647,11 @@ do
 			if timer:match("d%d+") then -- parse doubling timers, e.g. "d20"
 				allowdouble = true
 				timer = tonumber(string.sub(timer, 2))
-			elseif timer:match("^v%d+-%d+") then -- parse variance, e.g. "v20-25"
+			elseif timer:match("^v%d+%.?%d*%-%d+%.?%d*$") then -- parse variance, e.g. "v20.5-25.5"
 				hasVariance = true
 				timerStringWithVariance = timer
 				timer, minTimer, varianceDuration = parseVarianceFromTimer(timer)
-			elseif timer:match("^dv%d+-%d+") then -- parse doubling and variance, e.g. "dv20-25"
+			elseif timer:match("dv%d+%.?%d*%-%d+%.?%d*$") then -- parse doubling and variance, e.g. "dv20.5-25.5"
 				allowdouble = true
 				hasVariance = true
 				timerStringWithVariance = timer

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241210235130"),
+	Revision = parseCurseDate("20241212102112"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -10176,7 +10176,7 @@ do
 				if not self.fade and (type(countVoice) == "string" or countVoice > 0) then--Started without faded and has count voice assigned
 					DBM:Unschedule(playCountSound, id) -- Prevents count sound if timer is started again before timer expires
 					-- minTimer checks for the minimum possible timer in the variance timer string sent from Start method, self.minTimer is from newTimer constructor. Else, use timer value
-					playCountdown(id, minTimer or self.minTimer or timer, countVoice, countVoiceMax, self.requiresCombat)--timerId, timer, voice, count
+					playCountdown(id, minTimer or (hasVariance and self.minTimer) or timer, countVoice, countVoiceMax, self.requiresCombat)--timerId, timer, voice, count
 				end
 			end
 			-- timerStringWithVariance checks for timer string sent from Start method, self.timerStringWithVariance is from newTimer constructor. Else, use timer value

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241204193401"),
+	Revision = parseCurseDate("20241206223454"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -6527,14 +6527,14 @@ do
 		testTimer6:Stop("Handle your Role")
 		testTimer7:Stop("Next Stage")
 		testTimer8:Stop("Custom User Bar")
-		testTimer1:Start(10, "Test Bar")
-		testTimer2:Start(30, "Adds")
+		testTimer1:Start("v5-10", "Test Bar")
+		testTimer2:Start("v10-30", "Adds")
 		testTimer3:Start(43, "Evil Debuff")
 		testTimer4:Start(20, "Important Interrupt")
-		testTimer5:Start(60, "Boom!")
+		testTimer5:Start("v50-60", "Boom!")
 		testTimer6:Start(35, "Handle your Role")
 		testTimer7:Start(50, "Next Stage")
-		testTimer8:Start(55, "Custom User Bar")
+		testTimer8:Start("v50-55", "Custom User Bar")
 		testWarning1:Cancel()
 		testWarning2:Cancel()
 		testWarning3:Cancel()
@@ -9983,6 +9983,13 @@ do
 			if DBM.Options.DontShowBossTimers and not self.mod.isTrashMod then return end
 			if DBM.Options.DontShowTrashTimers and self.mod.isTrashMod then return end
 		end
+		local timerStringWithVariance, minTimer, maxTimer
+		if type(timer) == "string" and timer:match("^v%d+-%d+$") then -- catch "timer variance" pattern, expressed like v10-20
+			timerStringWithVariance = timer -- cache timer string
+			minTimer, maxTimer = timer:match("v(%d+)-(%d+)")
+			minTimer, maxTimer = tonumber(minTimer), tonumber(maxTimer)
+			timer = maxTimer -- use highest possible value as the actual End timer
+		end
 		if timer and type(timer) ~= "number" then
 			return self:Start(nil, timer, ...) -- first argument is optional!
 		end
@@ -10099,10 +10106,10 @@ do
 				countVoice = self.mod.Options[self.option .. "CVoice"]
 				if not self.fade and (type(countVoice) == "string" or countVoice > 0) then--Started without faded and has count voice assigned
 					DBM:Unschedule(playCountSound, id) -- Prevents count sound if timer is started again before timer expires
-					playCountdown(id, timer, countVoice, countVoiceMax, self.requiresCombat)--timerId, timer, voice, count
+					playCountdown(id, minTimer or timer, countVoice, countVoiceMax, self.requiresCombat)--timerId, timer, voice, count
 				end
 			end
-			local bar = DBT:CreateBar(timer, id, self.icon, nil, nil, nil, nil, colorId, nil, self.keep, self.fade, countVoice, countVoiceMax)
+			local bar = DBT:CreateBar(timerStringWithVariance or timer, id, self.icon, nil, nil, nil, nil, colorId, nil, self.keep, self.fade, countVoice, countVoiceMax)
 			if not bar then
 				return false, "error" -- creating the timer failed somehow, maybe hit the hard-coded timer limit of 15
 			end

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241207225353"),
+	Revision = parseCurseDate("20241208000140"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241208184611"),
+	Revision = parseCurseDate("20241208193735"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241206223454"),
+	Revision = parseCurseDate("20241207225353"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -6530,7 +6530,7 @@ do
 		testTimer1:Start("v5-10", "Test Bar")
 		testTimer2:Start("v10-30", "Adds")
 		testTimer3:Start(43, "Evil Debuff")
-		testTimer4:Start(20, "Important Interrupt")
+		testTimer4:Start("v15-20", "Important Interrupt")
 		testTimer5:Start("v50-60", "Boom!")
 		testTimer6:Start(35, "Handle your Role")
 		testTimer7:Start(50, "Next Stage")

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241208222924"),
+	Revision = parseCurseDate("20241208233607"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241212214114"),
+	Revision = parseCurseDate("20241214105403"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -9978,35 +9978,23 @@ do
 		end
 	end
 
+	-- Parse variance from timer string (v30.5-40" or "dv30.5-40"), into minimum and maximum timer, and calculated variance duration
+	---@param timer string
+	---@return number maxTimer, number minTimer, number varianceDuration
 	local function parseVarianceFromTimer(timer)
-		if not timer then
-			DBM:Debug("|cffff0000No timer passed to parseVarianceFromTimer function.|r")
-			return
-		end
+		-- ^(d?v) matches starting character d (optional) or v
+		-- (%d+%.?%d*) matches any number of digits with optional decimal
+		-- %- matches literal character "-"
+		-- (%d+%.?%d*)$ matches any number of digits with optional decimal, at the end of the string
+		local minTimer, maxTimer = timer:match("v(%d+%.?%d*)%-(%d+%.?%d*)")
+		minTimer, maxTimer = tonumber(minTimer), tonumber(maxTimer)
+		if type(minTimer) ~= "number" or type(maxTimer) ~= "number" then
+			DBM:Debug("|cffff0000No timers found in the string passed to parseVarianceFromTimer function: "..timer..". Returning zero.|r")
+			return 0, 0, 0
+			end
+		local varianceDuration = maxTimer - minTimer
 
-		if type(timer) == "number" then
-			if timer <= 0 then return end
-
-			return timer -- Normal number timer, no variance
-		end
-
-		-- Check for variance format like "v30.5-40" or "dv30.5-40"
-		if type(timer) == "string" then
-			-- ^(d?v) matches starting character d (optional) or v
-			-- (%d+%.?%d*) matches any number of digits with optional decimal
-			-- %- matches literal character "-"
-			-- (%d+%.?%d*)$ matches any number of digits with optional decimal, at the end of the string
-			if not timer:match("^(d?v)(%d+%.?%d*)%-(%d+%.?%d*)$") then return end
-
-			local minTimer, maxTimer = timer:match("v(%d+%.?%d*)%-(%d+%.?%d*)")
-			minTimer, maxTimer = tonumber(minTimer), tonumber(maxTimer)
-			local varianceDuration = maxTimer - minTimer
-
-			return maxTimer, minTimer, varianceDuration  -- maximum possible timer from the variance window, minimum..., variance duration
-		end
-
-		DBM:Debug("|cffff0000Invalid input to parseVarianceFromTimer function.|r")
-		return -- Invalid input
+		return maxTimer, minTimer, varianceDuration  -- maximum possible timer from the variance window, minimum..., variance duration
 	end
 
 	local function correctWithVarianceDuration(numberToCorrect, timerBar)

--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -82,7 +82,7 @@ local function currentFullDate()
 end
 
 DBM = {
-	Revision = parseCurseDate("20241209223619"),
+	Revision = parseCurseDate("20241210235130"),
 	DisplayVersion = "10.1.13 alpha", -- the string that is shown as version
 	ReleaseRevision = releaseDate(2024, 07, 20) -- the date of the latest stable version that is available, optionally pass hours, minutes, and seconds for multiple releases in one day
 }
@@ -10028,8 +10028,10 @@ do
 			if DBM.Options.DontShowBossTimers and not self.mod.isTrashMod then return end
 			if DBM.Options.DontShowTrashTimers and self.mod.isTrashMod then return end
 		end
+		local hasVariance = type(timer) == "number" and false or not timer and self.hasVariance -- to separate from metadata, to account for metavariant timers with a fixed timer start, like timer:Start(10)
 		local timerStringWithVariance, minTimer
 		if type(timer) == "string" and timer:match("^v%d+%.?%d*-%d+%.?%d*$") then -- catch "timer variance" pattern, expressed like v10.5-20.5
+			hasVariance = true
 			timerStringWithVariance = timer -- cache timer string
 			timer, minTimer = parseVarianceFromTimer(timer) -- use highest possible value as the actual End timer
 		end
@@ -10053,7 +10055,7 @@ do
 										DBM:AddMsg("Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug")
 										fireEvent("DBM_Debug", "Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug", 2)
 									elseif bar.timer < -0.1 then -- Would be useful to implement a variance detector, and report outside the known variance, however this would need to happen on a timer after it was refreshed. For the moment, only "keep" arg can achieve this.
-										DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero. Remaining time is : "..remaining, 2)
+										DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero, outside known variance window. Remaining time is : "..remaining, 2)
 									elseif bar.timer > correctWithVarianceDuration(0.1, bar) then
 										DBM:Debug("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer..")", 2)
 									end
@@ -10142,7 +10144,7 @@ do
 									DBM:AddMsg("Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug")
 									fireEvent("DBM_Debug", "Timer "..ttext..phaseText.. " refreshed before expired, outside known variance window. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer.."). Please report this bug", 2)
 								elseif bar.timer < -0.1 then -- Would be useful to implement a variance detector, and report outside the known variance, however this would need to happen on a timer after it was refreshed. For the moment, only "keep" arg can achieve this.
-									DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero. Remaining time is : "..remaining, 2)
+									DBM:Debug("Timer "..ttext..phaseText.. " refreshed after zero, outside known variance window. Remaining time is : "..remaining, 2)
 								elseif bar.timer > correctWithVarianceDuration(0.1, bar) then
 									DBM:Debug("Timer "..ttext..phaseText.. " refreshed before expired. Remaining time is : "..remaining.." (until variance minimum timer: "..deltaFromVarianceMinTimer..")", 2)
 								end
@@ -10178,7 +10180,7 @@ do
 				end
 			end
 			-- timerStringWithVariance checks for timer string sent from Start method, self.timerStringWithVariance is from newTimer constructor. Else, use timer value
-			local bar = DBT:CreateBar(timerStringWithVariance or self.timerStringWithVariance or timer, id, self.icon, nil, nil, nil, nil, colorId, nil, self.keep, self.fade, countVoice, countVoiceMax)
+			local bar = DBT:CreateBar(timerStringWithVariance or (hasVariance and self.timerStringWithVariance) or timer, id, self.icon, nil, nil, nil, nil, colorId, nil, self.keep, self.fade, countVoice, countVoiceMax)
 			if not bar then
 				return false, "error" -- creating the timer failed somehow, maybe hit the hard-coded timer limit of 15
 			end

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -818,6 +818,23 @@ function barPrototype:SetVariance()
 	if self.hasVariance then
 		local varianceWidth = self.frame:GetWidth() * (self.varianceDuration / self.totalTime)
 		varianceTex:SetWidth(varianceWidth)
+
+		-- change SetPoints based on fillUpBars
+		local bar = _G[frame_name.."Bar"]
+		varianceTex:ClearAllPoints()
+		local isEnlarged = self.enlarged and not self.paused
+		local fillUpBars = isEnlarged and DBT.Options.FillUpLargeBars or not isEnlarged and DBT.Options.FillUpBars
+
+		if fillUpBars then
+			varianceTex:SetPoint("RIGHT", bar, "RIGHT")
+			varianceTex:SetPoint("TOPRIGHT", bar, "TOPRIGHT")
+			varianceTex:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT")
+		else
+			varianceTex:SetPoint("LEFT", bar, "LEFT")
+			varianceTex:SetPoint("TOPLEFT", bar, "TOPLEFT")
+			varianceTex:SetPoint("BOTTOMLEFT", bar, "BOTTOMLEFT")
+		end
+
 		varianceTex:Show()
 	else
 		varianceTex:Hide()

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -306,11 +306,15 @@ do
 			return timer -- Normal number timer, no variance
 		end
 
-		-- Check for variance format like "v30-40"
+		-- Check for variance format like "v30.5-40" or "dv30.5-40"
 		if type(timer) == "string" then
-			if not timer:match("^v(%d+)%-(%d+)$") then return end
+			-- ^v matches starting character d (optional) or v
+			-- (%d+%.?%d*) matches any number of digits with optional decimal
+			-- %- matches literal character "-"
+			-- (%d+%.?%d*)$ matches any number of digits with optional decimal, at the end of the string
+			if not timer:match("^v(%d+%.?%d*)%-(%d+%.?%d*)$") then return end
 
-			local minTimer, maxTimer = timer:match("v(%d+)%-(%d+)")
+			local minTimer, maxTimer = timer:match("v(%d+%.?%d*)%-(%d+%.?%d*)")
 			minTimer, maxTimer = tonumber(minTimer), tonumber(maxTimer)
 			local varianceDuration = maxTimer - minTimer
 

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -398,7 +398,7 @@ do
 				newFrame.obj = newBar
 			end
 			self.numBars = self.numBars + 1
-			if ((colorType and colorType == 7 and self.Options.Bar7ForceLarge) or (timer <= (self.Options.EnlargeBarTime or 11) or huge)) and self.Options.HugeBarsEnabled then -- Start enlarged
+			if ((colorType and colorType == 7 and self.Options.Bar7ForceLarge) or ((varianceMinTimer or timer) <= (self.Options.EnlargeBarTime or 11) or huge)) and self.Options.HugeBarsEnabled then -- Start enlarged
 				newBar.enlarged = true
 				newBar.huge = true
 				tinsert(largeBars, newBar)
@@ -849,6 +849,7 @@ function barPrototype:Update(elapsed)
 	local paused = self.paused
 	self.timer = self.timer - (paused and 0 or elapsed)
 	local timerValue = self.timer
+	local timerLowestValueFromVariance = self.varianceDuration and timerValue - self.varianceDuration or timerValue
 	local totaltimeValue = self.totalTime
 	local barOptions = DBT.Options
 	local currentStyle = barOptions.BarStyle
@@ -996,7 +997,7 @@ function barPrototype:Update(elapsed)
 		self:ApplyStyle()
 		DBT:UpdateBars(true)
 	end
-	if not paused and (timerValue <= enlargeTime) and not self.small and not isEnlarged and isMoving ~= "enlarge" and enlargeEnabled then
+	if not paused and (timerLowestValueFromVariance <= enlargeTime) and not self.small and not isEnlarged and isMoving ~= "enlarge" and enlargeEnabled then
 		self:RemoveFromList()
 		self:Enlarge()
 	end

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -1001,7 +1001,6 @@ function barPrototype:Update(elapsed)
 		self:Enlarge()
 	end
 	DBT:UpdateBars()
-	self:SetVariance() -- OPTIMIZE! Does not need to run all the time!
 end
 
 function barPrototype:RemoveFromList()
@@ -1094,6 +1093,7 @@ function barPrototype:ApplyStyle()
 		icon1:SetSize(sizeHeight, sizeHeight)
 		icon2:SetSize(sizeHeight, sizeHeight)
 	end
+	self:SetVariance()
 	self.frame:Show()
 	if sparkEnabled then
 		spark:SetAlpha(1)

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -314,7 +314,7 @@ do
 			minTimer, maxTimer = tonumber(minTimer), tonumber(maxTimer)
 			local varianceDuration = maxTimer - minTimer
 
-			return maxTimer, minTimer, varianceDuration  -- Total duration, variance duration
+			return maxTimer, minTimer, varianceDuration  -- maximum possible timer from the variance window, minimum..., variance duration
 		end
 
 		return -- Invalid input

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -285,9 +285,16 @@ do
 		varianceTex:SetPoint("RIGHT", bar, "RIGHT")
 		varianceTex:SetPoint("TOPRIGHT", bar, "TOPRIGHT")
 		varianceTex:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT")
-		varianceTex:SetTexture("Interface\\TargetingFrame\\UI-StatusBar.blp")
+		varianceTex:SetTexture("Interface\\TargetingFrame\\UI-StatusBar")
 		varianceTex:SetWidth(20)
 		varianceTex:SetBlendMode("ADD")
+
+		local varianceTexBorder = bar:CreateTexture("$parentVarianceBorder", "OVERLAY")
+		varianceTexBorder:SetVertexColor(0, 0, 0, 1)
+		varianceTexBorder:SetPoint("TOPLEFT", varianceTex, "TOPLEFT", -1, 0)
+		varianceTexBorder:SetPoint("BOTTOMLEFT", varianceTex, "BOTTOMLEFT", -1, 0)
+		varianceTexBorder:SetTexture("Interface\\Buttons\\WHITE8X8")
+		varianceTexBorder:SetWidth(1)
 
 		fCounter = fCounter + 1
 
@@ -815,6 +822,7 @@ end
 function barPrototype:SetVariance()
 	local frame_name = self.frame:GetName()
 	local varianceTex = _G[frame_name.."BarVariance"]
+	local varianceTexBorder = _G[frame_name.."BarVarianceBorder"]
 	if self.hasVariance then
 		local varianceWidth = self.frame:GetWidth() * (self.varianceDuration / self.totalTime)
 		varianceTex:SetWidth(varianceWidth)
@@ -822,6 +830,7 @@ function barPrototype:SetVariance()
 		-- change SetPoints based on fillUpBars
 		local bar = _G[frame_name.."Bar"]
 		varianceTex:ClearAllPoints()
+		varianceTexBorder:ClearAllPoints()
 		local isEnlarged = self.enlarged and not self.paused
 		local fillUpBars = isEnlarged and DBT.Options.FillUpLargeBars or not isEnlarged and DBT.Options.FillUpBars
 
@@ -829,15 +838,21 @@ function barPrototype:SetVariance()
 			varianceTex:SetPoint("RIGHT", bar, "RIGHT")
 			varianceTex:SetPoint("TOPRIGHT", bar, "TOPRIGHT")
 			varianceTex:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT")
+			varianceTexBorder:SetPoint("TOPLEFT", varianceTex, "TOPLEFT", -1, 0)
+			varianceTexBorder:SetPoint("BOTTOMLEFT", varianceTex, "BOTTOMLEFT", -1, 0)
 		else
 			varianceTex:SetPoint("LEFT", bar, "LEFT")
 			varianceTex:SetPoint("TOPLEFT", bar, "TOPLEFT")
 			varianceTex:SetPoint("BOTTOMLEFT", bar, "BOTTOMLEFT")
+			varianceTexBorder:SetPoint("TOPRIGHT", varianceTex, "TOPRIGHT", 1, 0)
+			varianceTexBorder:SetPoint("BOTTOMRIGHT", varianceTex, "BOTTOMRIGHT", 1, 0)
 		end
 
 		varianceTex:Show()
+		varianceTexBorder:Show()
 	else
 		varianceTex:Hide()
+		varianceTexBorder:Hide()
 	end
 end
 


### PR DESCRIPTION
Work in progress:

https://github.com/user-attachments/assets/8776d7ec-5322-462b-83e8-6d1c1da00ccd

To do:

- [x] Refactor DBT (SetVariance must be placed elsewhere so it only runs on bar width changes) - https://github.com/Zidras/DBM-Warmane/pull/233/commits/ecefca4dba468d30b7928c141bc4cba16681940c
- [x] Implement on FillUp - https://github.com/Zidras/DBM-Warmane/pull/233/commits/80f86f0f2f43045cf2b136ec5d7c71784eac8a7f
- [x] Account for decimal timers - https://github.com/Zidras/DBM-Warmane/pull/233/commits/f348b6d11d60031d0c9bc68e402d599b60251f75
- [x] Make it so enlarge is triggered based on minTime, instead of Max - https://github.com/Zidras/DBM-Warmane/pull/233/commits/6af0213d45f14a89df72620715a4ab72a65c5bcf
- [x] Implement on newTimer - https://github.com/Zidras/DBM-Warmane/pull/233/commits/3d6e301ccbbada697c65788d12d96a30a9c01830
- [x] Implement variance on allowdouble - https://github.com/Zidras/DBM-Warmane/pull/233/commits/3d6e301ccbbada697c65788d12d96a30a9c01830
- [x] Debug must discard refreshes inside variance window - https://github.com/Zidras/DBM-Warmane/pull/233/commits/7b7ccd147df360bf9640edd98bba3287f3a56f9b
- [x] Complete Start method