### PR TITLE
Instructor Razuvious: Add icon to Disrupting Shout

### DIFF
--- a/DBM-Naxx/MilitaryQuarter/Razuvious.lua
+++ b/DBM-Naxx/MilitaryQuarter/Razuvious.lua
@@ -12,11 +12,11 @@ mod:RegisterEventsInCombat(
 	"UNIT_DIED"
 )
 
-local warnShoutNow		= mod:NewSpellAnnounce(29107, 1)
-local warnShoutSoon		= mod:NewSoonAnnounce(29107, 3)
+local warnShoutNow		= mod:NewSpellAnnounce(29107, 1, "Interface\\Icons\\Ability_Warrior_RallyingCry")
+local warnShoutSoon		= mod:NewSoonAnnounce(29107, 3, "Interface\\Icons\\Ability_Warrior_RallyingCry")
 local warnShieldWall	= mod:NewAnnounce("WarningShieldWallSoon", 3, 29061, nil, nil, nil, 29061)
 
-local timerShout		= mod:NewNextTimer(15, 29107, nil, nil, nil, 2)
+local timerShout		= mod:NewNextTimer(15, 29107, nil, nil, nil, 2, "Interface\\Icons\\Ability_Warrior_RallyingCry")
 local timerTaunt		= mod:NewCDTimer(20, 29060, nil, nil, nil, 5, nil, DBM_COMMON_L.TANK_ICON)
 local timerShieldWall	= mod:NewCDTimer(20, 29061, nil, nil, nil, 5, nil, DBM_COMMON_L.TANK_ICON)
 local timerMindControl	= mod:NewBuffActiveTimer(60, 605, nil, nil, nil, 6)

--- a/DBM-Naxx/MilitaryQuarter/Razuvious.lua
+++ b/DBM-Naxx/MilitaryQuarter/Razuvious.lua
@@ -12,11 +12,11 @@ mod:RegisterEventsInCombat(
 	"UNIT_DIED"
 )
 
-local warnShoutNow		= mod:NewSpellAnnounce(29107, 1, "Interface\\Icons\\Ability_Warrior_RallyingCry")
-local warnShoutSoon		= mod:NewSoonAnnounce(29107, 3, "Interface\\Icons\\Ability_Warrior_RallyingCry")
+local warnShoutNow		= mod:NewSpellAnnounce(29107, 1, "Interface\\Icons\\Ability_Warrior_Rampage")
+local warnShoutSoon		= mod:NewSoonAnnounce(29107, 3, "Interface\\Icons\\Ability_Warrior_Rampage")
 local warnShieldWall	= mod:NewAnnounce("WarningShieldWallSoon", 3, 29061, nil, nil, nil, 29061)
 
-local timerShout		= mod:NewNextTimer(15, 29107, nil, nil, nil, 2, "Interface\\Icons\\Ability_Warrior_RallyingCry")
+local timerShout		= mod:NewNextTimer(15, 29107, nil, nil, nil, 2, "Interface\\Icons\\Ability_Warrior_Rampage")
 local timerTaunt		= mod:NewCDTimer(20, 29060, nil, nil, nil, 5, nil, DBM_COMMON_L.TANK_ICON)
 local timerShieldWall	= mod:NewCDTimer(20, 29061, nil, nil, nil, 5, nil, DBM_COMMON_L.TANK_ICON)
 local timerMindControl	= mod:NewBuffActiveTimer(60, 605, nil, nil, nil, 6)

--- a/DBM-Naxx/MilitaryQuarter/Razuvious.lua
+++ b/DBM-Naxx/MilitaryQuarter/Razuvious.lua
@@ -1,7 +1,7 @@
 local mod	= DBM:NewMod("Razuvious", "DBM-Naxx", 4)
 local L		= mod:GetLocalizedStrings()
 
-mod:SetRevision("20221016184543")
+mod:SetRevision("20250924081528")
 mod:SetCreatureID(16061)
 
 mod:RegisterCombat("combat_yell", L.Yell1, L.Yell2, L.Yell3, L.Yell4)


### PR DESCRIPTION
The spell has no icon, so it's using the default engineering icon.

Added the https://www.wowhead.com/wotlk/icon=132351/ability-warrior-rallyingcry icon instead. I looked at some of the warrior icons and this seemed like the best fit. There is also this spell https://www.wowhead.com/wotlk/spell=42708/staggering-roar, which uses the same icon.