### PR TITLE
Variance: timer Update method now handles variant totalTime

### DIFF
--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -334,6 +334,7 @@ do
 
 		return -- Invalid input
 	end
+	DBT.parseTimer = parseTimer
 
 	function DBT:CreateBar(timer, id, icon, huge, small, color, isDummy, colorType, inlineIcon, keep, fade, countdown, countdownMax)
 		local varianceMaxTimer, varianceMinTimer, varianceDuration
@@ -689,6 +690,7 @@ function DBT:CancelBar(id)
 	end
 	return false
 end
+
 function DBT:ResetBarVariance(bar)
 	if bar.hasVariance then
 		bar.minTimer = nil
@@ -703,6 +705,18 @@ function DBT:UpdateBar(id, elapsed, totalTime)
 		if id == bar.id then
 			if type(totalTime) == "number" then
 				DBT:ResetBarVariance(bar)
+			elseif type(totalTime) == "string" then -- found string (variance)
+				local varianceMaxTimer, varianceMinTimer, varianceDuration
+				varianceMaxTimer, varianceMinTimer, varianceDuration = DBT.parseTimer(totalTime) -- either normal number or with variance
+				if self.Options.VarianceEnabled then
+					totalTime = varianceMaxTimer
+				else
+					totalTime = varianceMinTimer or varianceMaxTimer -- varianceMaxTimer here could be just normal number timer, so check for varianceMinTimer, which only exists if it's a variant timer
+				end
+				bar.minTimer = varianceMinTimer or nil
+				bar.varianceDuration = varianceDuration or 0
+				bar.hasVariance = varianceMinTimer and true or false
+				bar:ApplyStyle()
 			end
 			bar:SetTimer(totalTime or bar.totalTime)
 			bar:SetElapsed(elapsed or self.totalTime - self.timer)


### PR DESCRIPTION
https://github.com/Zidras/DBM-Warmane/blob/60d5858728efece43bdefcc231a76994b1c69e0c/DBM-Icecrown/TheFrozenThrone/LichKing.lua#L882-L885

This way of handling Soul Shriek was flawed in the sense that `totalTime` was being passed as an absolute value (from `:Time`) and there was no way for the existing Update method to receive a variant `totalTime`, nor leave it blank to re-use the meta timer.
This PR aims to implement parsing of variance out of `totalTime`, now allowing for the function to receive both absolute and variant timers.