### PR TITLE
SWP-Brutallus: Update check's for starting cd's timers of burn and stomp

### DIFF
--- a/DBM-Sunwell/Brutallus.lua
+++ b/DBM-Sunwell/Brutallus.lua
@@ -128,7 +128,7 @@ end
 function mod:SPELL_CAST_SUCCESS(args)
 	if args.spellId == 45185 then
 		timerStompCD:Start()
-	elseif args.SpellID == 45141 then
+	elseif args.spellId == 45141 then
 		timerBurnCD:Start()
 	end
 end


### PR DESCRIPTION
Arguments were taken from this log, since transcriptor sadly didnt save the fight bcoz of a wow crash
[WoWCombatLog.zip](https://github.com/user-attachments/files/23387436/WoWCombatLog.zip)
