### PR TITLE
DBT: fix huge bars not restarting fill on enlarge #252

### DIFF
--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -989,14 +989,14 @@ function barPrototype:Update(elapsed)
 		return self:Cancel()
 	else
 		if fillUpBars then
-			if currentStyle == "NoAnim" and timerValue <= enlargeTime and not enlargeHack and not self.varianceDuration then
+			if currentStyle == "NoAnim" and timerValue <= enlargeTime and not enlargeHack and not (varianceEnabled and self.hasVariance) then
 				-- Simple/NoAnim Bar mimics BW in creating a new bar on large bar anchor instead of just moving the small bar
 				bar:SetValue(1 - timerValue/(totaltimeValue < enlargeTime and totaltimeValue or enlargeTime))
 			else
 				bar:SetValue(1 - timerValue/totaltimeValue)
 			end
 		else
-			if currentStyle == "NoAnim" and timerValue <= enlargeTime and not enlargeHack and not self.varianceDuration then
+			if currentStyle == "NoAnim" and timerValue <= enlargeTime and not enlargeHack and not (varianceEnabled and self.hasVariance) then
 				-- Simple/NoAnim Bar mimics BW in creating a new bar on large bar anchor instead of just moving the small bar
 				bar:SetValue(timerValue/(totaltimeValue < enlargeTime and totaltimeValue or enlargeTime))
 			else

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -862,14 +862,21 @@ function barPrototype:SetVariance()
 	local varianceTex = _G[frame_name.."BarVariance"]
 	local varianceTexBorder = _G[frame_name.."BarVarianceBorder"]
 	if DBT.Options.VarianceEnabled and self.hasVariance then
-		local varianceWidth = self.frame:GetWidth() * (self.varianceDuration / self.totalTime)
+		local isEnlarged = self.enlarged and not self.paused
+		local varianceScaleTime = self.totalTime
+		if isEnlarged and DBT.Options.BarStyle == "NoAnim" and not (self.dummyEnlarge or self.colorType == 7 and DBT.Options.Bar7ForceLarge) then
+			local enlargeRebaseTime = (DBT.Options.EnlargeBarTime or 11) + self.varianceDuration
+			if enlargeRebaseTime < varianceScaleTime then
+				varianceScaleTime = enlargeRebaseTime
+			end
+		end
+		local varianceWidth = self.frame:GetWidth() * (self.varianceDuration / varianceScaleTime)
 		varianceTex:SetWidth(varianceWidth)
 
 		-- change SetPoints based on fillUpBars
 		local bar = _G[frame_name.."Bar"]
 		varianceTex:ClearAllPoints()
 		varianceTexBorder:ClearAllPoints()
-		local isEnlarged = self.enlarged and not self.paused
 		local fillUpBars = isEnlarged and DBT.Options.FillUpLargeBars or not isEnlarged and DBT.Options.FillUpBars
 
 		if fillUpBars then
@@ -953,6 +960,7 @@ function barPrototype:Update(elapsed)
 	--	local varianceBehaviorZeroMax = varianceEnabled self.hasVariance and barOptions.VarianceBehavior == "ZeroAtMaxTimer"
 	local varianceBehaviorNeg = varianceEnabled and self.hasVariance and barOptions.VarianceBehavior == "ZeroAtMinTimerAndNeg"
 	local timerCorrectedNegative = varianceBehaviorNeg and timerLowestValueFromVariance or timerValue
+	local enlargeRebaseTime = varianceEnabled and self.hasVariance and enlargeTime + self.varianceDuration or enlargeTime
 	if barOptions.DynamicColor and not self.color then
 		local r, g, b
 		if colorCount and colorCount >= 1 then
@@ -989,16 +997,16 @@ function barPrototype:Update(elapsed)
 		return self:Cancel()
 	else
 		if fillUpBars then
-			if currentStyle == "NoAnim" and timerValue <= enlargeTime and not enlargeHack and not (varianceEnabled and self.hasVariance) then
+			if currentStyle == "NoAnim" and timerValue <= enlargeRebaseTime and not enlargeHack then
 				-- Simple/NoAnim Bar mimics BW in creating a new bar on large bar anchor instead of just moving the small bar
-				bar:SetValue(1 - timerValue/(totaltimeValue < enlargeTime and totaltimeValue or enlargeTime))
+				bar:SetValue(1 - timerValue/(totaltimeValue < enlargeRebaseTime and totaltimeValue or enlargeRebaseTime))
 			else
 				bar:SetValue(1 - timerValue/totaltimeValue)
 			end
 		else
-			if currentStyle == "NoAnim" and timerValue <= enlargeTime and not enlargeHack and not (varianceEnabled and self.hasVariance) then
+			if currentStyle == "NoAnim" and timerValue <= enlargeRebaseTime and not enlargeHack then
 				-- Simple/NoAnim Bar mimics BW in creating a new bar on large bar anchor instead of just moving the small bar
-				bar:SetValue(timerValue/(totaltimeValue < enlargeTime and totaltimeValue or enlargeTime))
+				bar:SetValue(timerValue/(totaltimeValue < enlargeRebaseTime and totaltimeValue or enlargeRebaseTime))
 			else
 				bar:SetValue(timerValue/totaltimeValue)
 			end

--- a/DBM-StatusBarTimers/DBT.lua
+++ b/DBM-StatusBarTimers/DBT.lua
@@ -864,7 +864,7 @@ function barPrototype:SetVariance()
 	if DBT.Options.VarianceEnabled and self.hasVariance then
 		local isEnlarged = self.enlarged and not self.paused
 		local varianceScaleTime = self.totalTime
-		if isEnlarged and DBT.Options.BarStyle == "NoAnim" and not (self.dummyEnlarge or self.colorType == 7 and DBT.Options.Bar7ForceLarge) then
+		if isEnlarged and not self.huge and DBT.Options.BarStyle == "NoAnim" and not (self.dummyEnlarge or self.colorType == 7 and DBT.Options.Bar7ForceLarge) then
 			local enlargeRebaseTime = (DBT.Options.EnlargeBarTime or 11) + self.varianceDuration
 			if enlargeRebaseTime < varianceScaleTime then
 				varianceScaleTime = enlargeRebaseTime
@@ -961,6 +961,7 @@ function barPrototype:Update(elapsed)
 	local varianceBehaviorNeg = varianceEnabled and self.hasVariance and barOptions.VarianceBehavior == "ZeroAtMinTimerAndNeg"
 	local timerCorrectedNegative = varianceBehaviorNeg and timerLowestValueFromVariance or timerValue
 	local enlargeRebaseTime = varianceEnabled and self.hasVariance and enlargeTime + self.varianceDuration or enlargeTime
+	local rebaseFill = currentStyle == "NoAnim" and isEnlarged and not self.huge and not enlargeHack
 	if barOptions.DynamicColor and not self.color then
 		local r, g, b
 		if colorCount and colorCount >= 1 then
@@ -997,14 +998,14 @@ function barPrototype:Update(elapsed)
 		return self:Cancel()
 	else
 		if fillUpBars then
-			if currentStyle == "NoAnim" and timerValue <= enlargeRebaseTime and not enlargeHack then
+			if rebaseFill and timerValue <= enlargeRebaseTime then
 				-- Simple/NoAnim Bar mimics BW in creating a new bar on large bar anchor instead of just moving the small bar
 				bar:SetValue(1 - timerValue/(totaltimeValue < enlargeRebaseTime and totaltimeValue or enlargeRebaseTime))
 			else
 				bar:SetValue(1 - timerValue/totaltimeValue)
 			end
 		else
-			if currentStyle == "NoAnim" and timerValue <= enlargeRebaseTime and not enlargeHack then
+			if rebaseFill and timerValue <= enlargeRebaseTime then
 				-- Simple/NoAnim Bar mimics BW in creating a new bar on large bar anchor instead of just moving the small bar
 				bar:SetValue(timerValue/(totaltimeValue < enlargeRebaseTime and totaltimeValue or enlargeRebaseTime))
 			else


### PR DESCRIPTION
I spend some tokens on Fable 5 to pinpoint this issue. So far the testing results do look promising. But ngl, I don't understand all the changes. I hope it's not complete bullshit and i am not wasting your time with this 

The NoAnim "restart fill on the huge bar anchor" branch was dead code:
commit https://github.com/Zidras/DBM-Warmane/commit/2a4066f393c42195fb5117f347e8e8d8e1400ac8 gated it behind not self.varianceDuration, but
varianceDuration is initialized as varianceDuration or 0, and 0 is
truthy in Lua. So the check failed for every bar and enlarged bars
kept the small bar's fill fraction. ->This fixes the normal non variance bars.

Instead of just excluding variance bars again, give each bar a rebase
window (enlargeRebaseTime): EnlargeBarTime for normal bars, plus the
variance duration for variance bars. Since variance bars enlarge when
their displayed time (time until earliest trigger) hits EnlargeBarTime,
they now also start empty on the huge anchor, and the fill reaches the
variance overlay exactly when the displayed timer hits zero. SetVariance
scales the overlay of enlarged NoAnim bars by the same window so the
shaded region stays aligned with the rebased fill. ->This fixes the variance timers.

`Co-Authored-By: Claude Fable 5 noreply@anthropic.com`